### PR TITLE
after job wait, update the ansiblejob cr with the ansiblejob result

### DIFF
--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -7,6 +7,7 @@ spec:
   ttlSecondsAfterFinished: 3600
   template:
     spec:
+      serviceAccountName: tower-resource-operator
       containers:
       - name: joblaunch
         image: matburt/operator-job-run:latest

--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -16,7 +16,25 @@
         namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
         labels:
           tower_job_id: "{{ job.id }}"
+      statusAnsibleJob:
+        status: "{{ job.status }}"
 
 - name: Wait for job
   tower_job_wait:
     job_id: "{{ job.id }}"
+  register: job_result
+
+- name: Update AnsibleJob definition with Tower job result
+  k8s:
+    state: present
+    definition:
+      kind: AnsibleJob
+      apiVersion: tower.ansible.com/v1alpha1
+      metadata:
+        name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
+        namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+      statusAnsibleJob:
+        elapsed: "{{ job_result.elapsed }}"
+        finished: "{{ job_result.finished }}"
+        started: "{{ job_result.started }}"
+        status: "{{ job_result.status }}"


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

The current status is control by operator-sdk which represent the status of launching the kube job (not ansible job). As long as the kube job is launched successfully, then it's always going to show `Successful`. 
```
status:
  conditions:
  - ansibleResult:
      changed: 0
      completion: 2020-08-11T19:51:56.946445
      failures: 0
      ok: 5
      skipped: 0
    lastTransitionTime: "2020-08-11T19:50:52Z"
    message: Awaiting next reconciliation
    reason: Successful
    status: "True"
    type: Running
```

In this PR, we are introducing `statusAnsibleJob` which actually represent the ansible tower job status. See below:
When running:
```
  statusAnsibleJob:
    status: pending
```
When completed:
```
  statusAnsibleJob:
    elapsed: "6.196"
    finished: "2020-08-19T15:47:45.412138Z"
    started: "2020-08-19T15:47:39.216242Z"
    status: successful
```

So the end result will look something like this:

```
  status:
    conditions:
    - ansibleResult:
        changed: 0
        completion: 2020-08-19T15:47:51.316016
        failures: 0
        ok: 5
        skipped: 0
      lastTransitionTime: "2020-08-19T15:47:02Z"
      message: Awaiting next reconciliation
      reason: Successful
      status: "True"
      type: Running
  statusAnsibleJob:
    elapsed: "6.196"
    finished: "2020-08-19T15:47:45.412138Z"
    started: "2020-08-19T15:47:39.216242Z"
    status: successful
```