### PR TITLE
generate a unique kubejob name per ansible job reconcile

### DIFF
--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -12,19 +12,23 @@
     name: "{{ tower_auth_secret }}"
   register: tower_config_secret
 
+- name: Generate a Pseudorandom K8s Job name
+  set_fact:
+    k8s_job_name: "{{ meta.name + '-' + (99999999 | random | to_uuid)[:8] }}"
+
+- name: Start K8s Runner Job
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'job_definition.yml') }}"
+
 - name: Get Job Info
   k8s_info:
     api_version: batch/v1
     kind: Job
-    name: "{{ meta.name }}"
+    name: "{{ k8s_job_name }}"
     namespace: "{{ meta.namespace }}"
   register: job_information_output
 
 - name: Debug Job Information
   debug:
     var: job_information_output
-
-- name: Start K8s Runner Job
-  k8s:
-    state: present
-    definition: "{{ lookup('template', 'job_definition.yml') }}"

--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -1,12 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ meta.name }}"
+  name: "{{ k8s_job_name }}"
   namespace: "{{ meta.namespace }}"
 spec:
   ttlSecondsAfterFinished: 3600
   template:
     spec:
+      serviceAccountName: tower-resource-operator
       containers:
       - name: joblaunch
         image: matburt/operator-job-run:latest


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

When launching the kube job the name should be unique enough so that when the AnsibleJob CR updates and causes a reconcile, it will launch another job without any errors.

Sample output:
```
NAME                    COMPLETIONS   DURATION   AGE
bigjoblaunch-52d50d7f   1/1           50s        4m4s
bigjoblaunch-c2dbfc02   1/1           21s        96s
```