### PR TITLE
use the k8s_status module to perform status update for ansiblejob result

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,5 @@ collections:
   - name: awx.awx
     version: ">=13.0.0"
   - community.kubernetes
-  - operator_sdk.util
+  - name: operator_sdk.util
+    version: ">=0.1.0"

--- a/roles/job_runner/meta/main.yml
+++ b/roles/job_runner/meta/main.yml
@@ -1,0 +1,2 @@
+collections:
+- operator_sdk.util

--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -16,7 +16,18 @@
         namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
         labels:
           tower_job_id: "{{ job.id }}"
-      statusAnsibleJob:
+
+- name: Update AnsibleJob status with Tower job status
+  k8s_status:
+    api_version: tower.ansible.com/v1alpha1
+    kind: AnsibleJob
+    name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
+    namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+    status:
+      ansibleJobResult:
+        elapsed:
+        finished:
+        started:
         status: "{{ job.status }}"
 
 - name: Wait for job
@@ -24,16 +35,14 @@
     job_id: "{{ job.id }}"
   register: job_result
 
-- name: Update AnsibleJob definition with Tower job result
-  k8s:
-    state: present
-    definition:
-      kind: AnsibleJob
-      apiVersion: tower.ansible.com/v1alpha1
-      metadata:
-        name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
-        namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
-      statusAnsibleJob:
+- name: Update AnsibleJob status with Tower job result
+  k8s_status:
+    api_version: tower.ansible.com/v1alpha1
+    kind: AnsibleJob
+    name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
+    namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+    status:
+      ansibleJobResult:
         elapsed: "{{ job_result.elapsed }}"
         finished: "{{ job_result.finished }}"
         started: "{{ job_result.started }}"


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Move the `statusAnsibleJob` into the proper `status` field. Now it looks like this
```
  status:
    ansibleJobResult:
      elapsed: "6.056"
      finished: "2020-08-20T19:43:44.699370Z"
      started: "2020-08-20T19:43:38.642954Z"
      status: successful
    conditions:
    - ansibleResult:
        changed: 1
        completion: 2020-08-20T19:42:56.679398
        failures: 0
        ok: 6
        skipped: 0
      lastTransitionTime: "2020-08-20T19:42:51Z"
      message: Awaiting next reconciliation
      reason: Successful
      status: "True"
      type: Running
```

The `ansibleJobResult` is the actual tower job result we are launching. 
The `ansibleResult` is the status that operator-sdk stamps for reporting the status of kicking off the k8s job that launches the ansible job.

Please note that:
```
        elapsed:
        finished:
        started:
```
it's an intentional change. This is for clearing the values when AnsibleJob CR updates and it reconciles again (which spawns another job) so while it's in `pending` status, these values should be blanked instead of the previous job result values.