### PR TITLE
use extra_vars and inventory when launching job

### DIFF
--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -34,6 +34,8 @@ spec:
               inventory:
                 type: string
               extra_vars:
+                description: extra_vars is a JSON string. For example,
+                  '{"version":"1.23.45","other_variable":"foo","pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
                 type: string
             required:
             - tower_auth_secret

--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -32,13 +32,9 @@ spec:
               job_template_name:
                 type: string
               inventory:
-                type: array
-                items:
-                  type: object
+                type: string
               extra_vars:
-                type: array
-                items:
-                  type: object
+                type: string
             required:
             - tower_auth_secret
             type: object

--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -34,9 +34,8 @@ spec:
               inventory:
                 type: string
               extra_vars:
-                description: extra_vars is a JSON string. For example,
-                  '{"version":"1.23.45","other_variable":"foo","pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
-                type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             required:
             - tower_auth_secret
             type: object

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -228,13 +228,11 @@ spec:
               job_template_name:
                 type: string
               inventory:
-                type: array
-                items:
-                  type: object
+                type: string
               extra_vars:
-                type: array
-                items:
-                  type: object
+                description: extra_vars is a JSON string. For example,
+                  '{"version":"1.23.45","other_variable":"foo","pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
+                type: string
             required:
             - tower_auth_secret
             type: object

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -230,9 +230,8 @@ spec:
               inventory:
                 type: string
               extra_vars:
-                description: extra_vars is a JSON string. For example,
-                  '{"version":"1.23.45","other_variable":"foo","pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
-                type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             required:
             - tower_auth_secret
             type: object

--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -1,8 +1,18 @@
 ---
 
+- name: Read AnsibleJob Specs
+  k8s_info:
+    kind: AnsibleJob
+    api_version: tower.ansible.com/v1alpha1
+    name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
+    namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+  register: ansible_job
+
 - name: Launch a job
   awx.awx.tower_job_launch:
     job_template: "{{ lookup('env','TOWER_JOB_TEMPLATE_NAME') }}"
+    extra_vars: "{{ ansible_job['resources'][0]['spec']['extra_vars'] | default(omit) }}"
+    inventory: "{{ ansible_job['resources'][0]['spec']['inventory'] | default(omit) }}"
   register: job
 
 - name: Update AnsibleJob definition with Tower job id


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

*edited after discussion in comments.

- update the CRD for `inventory` to string type.
- update the CRD for `extra_vars` to be object type to best mimic python `dict` data type.
- pass in the `inventory` and/or `extra_vars` to launch tower job.

An AnsibleJob CR example with `extra_vars`:
```
apiVersion: tower.ansible.com/v1alpha1
kind: AnsibleJob
metadata:
  name: bigjoblaunch
spec:
  tower_auth_secret: toweraccess
  job_template_name: Target Clusters Template
  extra_vars: 
    target_clusters: ["aaa_cluster","bbb_cluster","ccc_cluster"]
```