### PR TITLE
parameterized the job runner image

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -37,6 +37,9 @@ spec:
               value: explicit
             - name: ANSIBLE_DEBUG_LOGS
               value: "True"
+            - name: ANSIBLE_JOB_RUNNER_IMAGE
+              # Replace this with the job runner built image name
+              value: "matburt/operator-job-run:latest"
       volumes:
         - name: runner
           emptyDir: {}

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -151,6 +151,9 @@ spec:
               value: explicit
             - name: ANSIBLE_DEBUG_LOGS
               value: "True"
+            - name: ANSIBLE_JOB_RUNNER_IMAGE
+              # Replace this with the job runner built image name
+              value: "matburt/operator-job-run:latest"
       volumes:
         - name: runner
           emptyDir: {}

--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -10,7 +10,7 @@ spec:
       serviceAccountName: tower-resource-operator
       containers:
       - name: joblaunch
-        image: matburt/operator-job-run:latest
+        image: "{{ lookup('env', 'ANSIBLE_JOB_RUNNER_IMAGE') }}"
         env:
           - name: TOWER_OAUTH_TOKEN
             value: "{{ tower_config_secret['resources'][0]['data']['token'] | b64decode }}"


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

The current job runner image is hardcoded into the job_definition.yml.
This change is to:
- expose the job runner image configuration upfront. 
- allows the job runner image to be updated dynamically by modifying the deployment during runtime without needing a new build.