### PR TITLE
revert unique k8s job name change

### DIFF
--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -17,10 +17,6 @@
     that:
       - tower_config_secret["resources"] is defined and (tower_config_secret["resources"]|length>0)
     fail_msg: "Tower Secret must exists"
-    
-- name: Generate a Pseudorandom K8s Job name
-  set_fact:
-    k8s_job_name: "{{ meta.name + '-' + (99999999 | random | to_uuid)[:8] }}"
 
 - name: Start K8s Runner Job
   k8s:
@@ -31,7 +27,7 @@
   k8s_info:
     api_version: batch/v1
     kind: Job
-    name: "{{ k8s_job_name }}"
+    name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
   register: job_information_output
 

--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ k8s_job_name }}"
+  name: "{{ meta.name }}"
   namespace: "{{ meta.namespace }}"
 spec:
   ttlSecondsAfterFinished: 3600


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

This is to revert the change that was done in https://github.com/ansible/awx-resource-operator/pull/4 As @xiangjingli points out in some cases, there is an infinite amount of jobs being spawned.

I am moving this change outside of https://github.com/ansible/awx-resource-operator/pull/9 so that PR can focus on the discussion around cluster scope. Also that PR moved the `Start K8s Runner Job` to after `Get Job Info` which is not accurate).

His original comment is:

In ansible job operator, we can't generate a unique k8s job name for running tower jobs. If so, the ansible job operator is triggered to launch  new k8s jobs in an endless loop.  In the following ansible task, the state is set to present, meaning  a k8s job will be created if it doesn't exist. 
```
- name: Start K8s Runner Job
  k8s:
    state: present
    definition: "{{ lookup('template', 'job_definition.yml') }}"
```
According to ansible k8s module guide, https://docs.ansible.com/ansible/latest/modules/k8s_module.html
```
state determines if an object should be created, patched, or deleted. When set to present, an object will be created, if it does not already exist
```