### PR TITLE
add job url to status.ansibleJobResult

### DIFF
--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -27,7 +27,7 @@
         labels:
           tower_job_id: "{{ job.id }}"
 
-- name: Update AnsibleJob status with Tower job status
+- name: Update AnsibleJob status with Tower job status and url
   k8s_status:
     api_version: tower.ansible.com/v1alpha1
     kind: AnsibleJob
@@ -39,6 +39,7 @@
         finished:
         started:
         status: "{{ job.status }}"
+        url: "{{lookup('env', 'TOWER_HOST') + '/#/jobs/playbook/' + (job.id|string)}}"
 
 - name: Wait for job
   tower_job_wait:


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Added `url` to AnsibleJob`status.ansibleJobResult` which represent the job url that it's running/ran for.

Example output:

```
  status:
    ansibleJobResult:
      elapsed: "6.172"
      finished: "2020-09-02T20:56:54.938639Z"
      started: "2020-09-02T20:56:48.766187Z"
      status: successful
      url: https://ansible-tower-web-svc-tower._redacted_.com/#/jobs/playbook/51
```

the `url` field name was chosen on purpose so that it sorts alphabetically in the `kubectl get -o yaml` output under `status.ansibleJobResult.status` 

Tested on Ansible Tower only. Please confirm this is the expected URL for AWX as well. Thanks.