### PR TITLE
end the play if the job is already running/ran + status update after creating k8s job

### DIFF
--- a/deploy/crds/tower.ansible.com_v1alpha1_joblaunch_cr.yaml
+++ b/deploy/crds/tower.ansible.com_v1alpha1_joblaunch_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: tower.ansible.com/v1alpha1
 kind: AnsibleJob
 metadata:
-  name: bigjoblaunch
+  name: demo-job
   namespace: awx
 spec:
   tower_auth_secret: toweraccess

--- a/deploy/crds/tower.ansible.com_v1alpha1_joblaunch_cr.yaml
+++ b/deploy/crds/tower.ansible.com_v1alpha1_joblaunch_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: tower.ansible.com/v1alpha1
 kind: AnsibleJob
 metadata:
-  name: demo-job
+  generateName: demo-job- # generate a unique suffix per 'kubectl create'
   namespace: awx
 spec:
   tower_auth_secret: toweraccess

--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-# tasks file for jobtemplate
-
-# - name: Show all vars
-#   debug:
-#     msg: "{{ vars }}"
 
 - name: Read K8s job info
   k8s_info:
@@ -21,7 +16,7 @@
       name: "{{ meta.name }}"
       namespace: "{{ meta.namespace }}"
       status:
-        message: "This job instance has already reached its end state. Create a new AnsibleJob if you wish to run the template again."
+        message: "This job instance is already running or has reached its end state."
   - name: End play early
     meta: end_play
   when: k8s_job["resources"] is defined and (k8s_job["resources"]|length>0)
@@ -44,3 +39,19 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'job_definition.yml') }}"
+
+- name: Update AnsibleJob status with K8s job info
+  k8s_status:
+    api_version: tower.ansible.com/v1alpha1
+    kind: AnsibleJob
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    status:
+      k8sJob:
+        created: true
+        message: "Monitor the K8s job status and log for more details"
+        namespacedName: "{{meta.namespace+'/'+meta.name}}"
+        env:
+          secretNamespacedName: "{{meta.namespace+'/'+tower_auth_secret}}"
+          templateName: "{{ job_template_name }}"
+          verifySSL: false

--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -5,11 +5,33 @@
 #   debug:
 #     msg: "{{ vars }}"
 
+- name: Read K8s job info
+  k8s_info:
+    kind: Job
+    api_version: batch/v1
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+  register: k8s_job
+
+- block:
+  - name: Update AnsibleJob status with message
+    k8s_status:
+      api_version: tower.ansible.com/v1alpha1
+      kind: AnsibleJob
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+      status:
+        message: "This job instance has already reached its end state. Create a new AnsibleJob if you wish to run the template again."
+  - name: End play early
+    meta: end_play
+  when: k8s_job["resources"] is defined and (k8s_job["resources"]|length>0)
+
 - name: Read Secret Configuration
   k8s_info:
     kind: Secret
-    namespace: '{{ meta.namespace }}'
+    api_version: v1
     name: "{{ tower_auth_secret }}"
+    namespace: "{{ meta.namespace }}"
   register: tower_config_secret
 
 - name: Validate Secret Exists
@@ -22,15 +44,3 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'job_definition.yml') }}"
-
-- name: Get Job Info
-  k8s_info:
-    api_version: batch/v1
-    kind: Job
-    name: "{{ meta.name }}"
-    namespace: "{{ meta.namespace }}"
-  register: job_information_output
-
-- name: Debug Job Information
-  debug:
-    var: job_information_output

--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -9,7 +9,7 @@ spec:
     spec:
       serviceAccountName: tower-resource-operator
       containers:
-      - name: joblaunch
+      - name: "{{ meta.name }}"
         image: "{{ lookup('env', 'ANSIBLE_JOB_RUNNER_IMAGE') }}"
         env:
           - name: TOWER_OAUTH_TOKEN

--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -8,12 +8,23 @@
     namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
   register: ansible_job
 
-- name: Launch a job
-  awx.awx.tower_job_launch:
-    job_template: "{{ lookup('env','TOWER_JOB_TEMPLATE_NAME') }}"
-    extra_vars: "{{ ansible_job['resources'][0]['spec']['extra_vars'] | default(omit) }}"
-    inventory: "{{ ansible_job['resources'][0]['spec']['inventory'] | default(omit) }}"
-  register: job
+- name: Launch a job if error update AnsibleJob status then end play
+  block:
+    - awx.awx.tower_job_launch:
+        job_template: "{{ lookup('env','TOWER_JOB_TEMPLATE_NAME') }}"
+        extra_vars: "{{ ansible_job['resources'][0]['spec']['extra_vars'] | default(omit) }}"
+        inventory: "{{ ansible_job['resources'][0]['spec']['inventory'] | default(omit) }}"
+      register: job
+  rescue:
+    - k8s_status:
+        api_version: tower.ansible.com/v1alpha1
+        kind: AnsibleJob
+        name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
+        namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+        status:
+          ansibleJobResult:
+            status: "error"
+    - meta: end_play
 
 - name: Update AnsibleJob definition with Tower job id
   k8s:

--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -1,5 +1,18 @@
 ---
 
+- name: Update status with K8s job info
+  k8s_status:
+    api_version: tower.ansible.com/v1alpha1
+    kind: AnsibleJob
+    name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
+    namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+    status:
+      ansibleK8sJob:
+        created: true
+        env:
+          templateName: "{{ lookup('env','TOWER_JOB_TEMPLATE_NAME') }}"
+          verifySSL: "{{ lookup('env','TOWER_VERIFY_SSL') }}"
+
 - name: Read AnsibleJob Specs
   k8s_info:
     kind: AnsibleJob

--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -1,18 +1,5 @@
 ---
 
-- name: Update status with K8s job info
-  k8s_status:
-    api_version: tower.ansible.com/v1alpha1
-    kind: AnsibleJob
-    name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
-    namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
-    status:
-      ansibleK8sJob:
-        created: true
-        env:
-          templateName: "{{ lookup('env','TOWER_JOB_TEMPLATE_NAME') }}"
-          verifySSL: "{{ lookup('env','TOWER_VERIFY_SSL') }}"
-
 - name: Read AnsibleJob Specs
   k8s_info:
     kind: AnsibleJob
@@ -48,9 +35,8 @@
     namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
     status:
       ansibleJobResult:
-        elapsed:
-        finished:
-        started:
+        changed: "{{ job.changed }}"
+        failed: "{{ job.failed }}"
         status: "{{ job.status }}"
         url: "{{lookup('env', 'TOWER_HOST') + '/#/jobs/playbook/' + (job.id|string)}}"
 


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

This PR is to address 2 issues:

1) When the operator restarts, all the AnsibleJobs that were previously ran will trigger again. 
With this PR, it will end the play and stamp the status with the following message:
```
...
    message: This job instance is already running or has reached its end state.
...
```

2) Currently, its not clear that the `awx.awx.tower_job_launch` failed to launch (ie a bad auth token)
when you look at the status when the tower job failed to launch you see:
```
  status:
    conditions:
    - ansibleResult:
        changed: 1
        completion: 2020-09-04T15:56:13.223679
        failures: 0
        ok: 6
        skipped: 0
      lastTransitionTime: "2020-09-04T15:56:04Z"
      message: Awaiting next reconciliation
      reason: Successful
      status: "True"
      type: Running
```
which represent the k8s job was created for the job runner successfully but doesn't have any info about the tower_job failed to launch. This is very confusing for users. You will have to log in the log of the k8s job to see that the tower_job failed.
```
oc logs job/demo-job-jd2rn
...
TASK [job_runner : Launch a job] ***********************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Invalid Tower authentication credentials for /api/v2/job_templates/ (HTTP 401)."}
...
```

- update job example cr name to be more sensible and use `generateName` to append a suffix for`kubectl create`
- remove the current get job info which exposes the token in the log, put some of the safe to show debug information into the status field.
- follow the common practice that the job container name should be the same as the job name
- use blocks for exception handling to set the `status.ansibleJobResult.status` to `error` when job launch errors.

The new status when the tower job failed to launch
```
  status:
    ansibleJobResult:
      status: error
    conditions:
    - ansibleResult:
        changed: 2
        completion: 2020-09-04T16:31:44.004288
        failures: 0
        ok: 6
        skipped: 1
      lastTransitionTime: "2020-09-04T16:31:33Z"
      message: Awaiting next reconciliation
      reason: Successful
      status: "True"
      type: Running
    k8sJob:
      created: true
      env:
        secretNamespacedName: default/toweraccess
        templateName: Demo Job Template
        verifySSL: false
      message: Monitor the K8s job status and log for more details
      namespacedName: default/demo-job-wdq2b
```
A tower job that ran successfully will have the following status:
```
  status:
    ansibleJobResult:
      changed: true
      elapsed: "6.235"
      failed: false
      finished: "2020-09-04T18:49:19.029458Z"
      started: "2020-09-04T18:49:12.794464Z"
      status: successful
      url: https://ansible-tower-web-svc-tower._redacted_.com/#/jobs/playbook/98
    conditions:
    - ansibleResult:
        changed: 2
        completion: 2020-09-04T18:48:24.829147
        failures: 0
        ok: 6
        skipped: 1
      lastTransitionTime: "2020-09-04T18:48:09Z"
      message: Awaiting next reconciliation
      reason: Successful
      status: "True"
      type: Running
    k8sJob:
      created: true
      env:
        secretNamespacedName: default/toweraccess
        templateName: Demo Job Template
        verifySSL: false
      message: Monitor the K8s job status and log for more details
      namespacedName: default/demo-job-m6dt8
```
Added `changed` and `failed` to `status.ansibleJobResult` in this PR.