### PR TITLE
Set role/rolebinding when a new ansible job cr is created outside of the ansible job operator namespace

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: tower-resource-operator
-  namespace: tower-operator
 rules:
 - apiGroups:
   - ""

--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -1,13 +1,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: tower-resource-operator
+  namespace: tower-operator
 rules:
 - apiGroups:
   - ""
+  - rbac.authorization.k8s.io
   resources:
   - pods
+  - serviceaccounts
+  - roles
+  - rolebindings
   - services
   - services/finalizers
   - endpoints

--- a/deploy/clusterrole_binding.yaml
+++ b/deploy/clusterrole_binding.yaml
@@ -1,8 +1,7 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tower-resource-operator
-  namespace: tower-operator
 subjects:
 - kind: ServiceAccount
   name: tower-resource-operator

--- a/deploy/crds/tower.ansible.com_v1alpha1_joblaunch_cr.yaml
+++ b/deploy/crds/tower.ansible.com_v1alpha1_joblaunch_cr.yaml
@@ -2,7 +2,19 @@ apiVersion: tower.ansible.com/v1alpha1
 kind: AnsibleJob
 metadata:
   name: bigjoblaunch
-  namespace: awx
+  namespace: default
 spec:
   tower_auth_secret: toweraccess
   job_template_name: Demo Job Template
+  extra_vars:
+    cost: 6.88
+    ghosts: ["inky","pinky","clyde","sue"]
+    is_enable: false
+    other_variable: foo
+    pacman: mrs
+    size: 8
+    targets_list:
+    - aaa
+    - bbb
+    - ccc
+    version: 1.23.45

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tower-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tower-resource-operator
+  namespace: tower-operator
 spec:
   replicas: 1
   selector:
@@ -24,9 +25,6 @@ spec:
             name: runner
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -2,10 +2,12 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tower-resource-operator
+  namespace: tower-operator
 subjects:
 - kind: ServiceAccount
   name: tower-resource-operator
+  namespace: tower-operator
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: tower-resource-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tower-resource-operator
+  namespace: tower-operator

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -1,5 +1,5 @@
 ---
-  apiVersion: v1
+apiVersion: v1
 kind: Namespace
 metadata:
   name: tower-operator

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -9,7 +9,6 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: tower-resource-operator
-  namespace: tower-operator
 rules:
 - apiGroups:
   - ""
@@ -107,11 +106,10 @@ rules:
   - watch
 
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tower-resource-operator
-  namespace: tower-operator
 subjects:
 - kind: ServiceAccount
   name: tower-resource-operator

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -126,6 +126,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tower-resource-operator
+  namespace: tower-operator
 
 ---
 apiVersion: apps/v1

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -1,14 +1,24 @@
 ---
+  apiVersion: v1
+kind: Namespace
+metadata:
+  name: tower-operator
+---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: tower-resource-operator
+  namespace: tower-operator
 rules:
 - apiGroups:
   - ""
+  - rbac.authorization.k8s.io
   resources:
   - pods
+  - serviceaccounts
+  - roles
+  - rolebindings
   - services
   - services/finalizers
   - endpoints
@@ -32,6 +42,7 @@ rules:
   - daemonsets
   - replicasets
   - statefulsets
+  - jobs
   verbs:
   - create
   - delete
@@ -59,6 +70,7 @@ rules:
   - ""
   resources:
   - pods
+  - jobs
   verbs:
   - get
 - apiGroups:
@@ -66,6 +78,7 @@ rules:
   resources:
   - replicasets
   - deployments
+  - jobs
   verbs:
   - get
 - apiGroups:
@@ -98,11 +111,13 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tower-resource-operator
+  namespace: tower-operator
 subjects:
 - kind: ServiceAccount
   name: tower-resource-operator
+  namespace: tower-operator
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: tower-resource-operator
   apiGroup: rbac.authorization.k8s.io
 
@@ -110,13 +125,14 @@ roleRef:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-    name: tower-resource-operator
+  name: tower-resource-operator
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tower-resource-operator
+  namespace: tower-operator
 spec:
   replicas: 1
   selector:
@@ -138,9 +154,6 @@ spec:
             name: runner
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -1,3 +1,23 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: tower-resource-operator
+    namespace: "{{ meta.namespace }}"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tower-resource-operator
+  namespace: "{{ meta.namespace }}"
+subjects:
+- kind: ServiceAccount
+  name: tower-resource-operator
+  namespace: "{{ meta.namespace }}"
+roleRef:
+  kind: ClusterRole
+  name: tower-resource-operator
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

1. set up a clusterRole `tower-resource-operator` when the ansible job operator is installed. The clusterRole will be used by the ansible job operator and Ansible k8s runner job as well.  Notice the clusterRole will be installed along with the ansilbe job operator CSV bundle.

2. Make ansible job operator cluster scopoed - watching all namespaces ansible job CRs.

3. Support to create Ansible job CR in any namespace, not only in ansible job operator namespace. This is done by  dynamically creating a  service account `tower-resource-operator` and a rolebinding in the same namespace to link to the opetaor clusterRole `tower-resource-operator` when the Ansible k8s runner job is created. The service account will be as the Ansible k8s runner job user. 

Without the role/rolebinding, the Ansible k8s runner job will fail if it is ouside of the ansible job operator namespace

4. Othere misc changes 
    - align individual  yaml resources to the unified tower-resource-operator.yaml, 
    - ansible job CR sample including extra_vars