### PR TITLE
build operator, runner, bundle images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+# opeator image
+IMG_OPERATOR ?= quay.io/open-cluster-management/aap-resource-operator:latest
+# runner image
+IMG_RUNNER ?= quay.io/open-cluster-management/aap-resource-runner:latest
+# bundle image version
+BUNDEL_VERSION ?= 0.1.0
+# bundle image
+IMG_BUNDLE ?= quay.io/open-cluster-management/aap-resource-operator-bundle:$(BUNDEL_VERSION)
+
+PATH  := $(PATH):$(PWD)/bin
+SHELL := env PATH=$(PATH) /bin/sh
+OS    = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH  = $(shell uname -m | sed 's/x86_64/amd64/')
+OSOPER   = $(shell uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/apple-darwin/' | sed 's/linux/linux-gnu/')
+ARCHOPER = $(shell uname -m )
+_OPERATOR_SDK_VERSION ?= v0.18.0
+
+############################################################
+# dependency section
+############################################################
+
+operator-sdk:
+ifeq (, $(shell which operator-sdk 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p bin ;\
+	curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${_OPERATOR_SDK_VERSION}/operator-sdk-${_OPERATOR_SDK_VERSION}-$(ARCHOPER)-$(OSOPER) ;\
+	mv operator-sdk-${_OPERATOR_SDK_VERSION}-$(ARCHOPER)-$(OSOPER) ./bin/operator-sdk ;\
+	chmod +x ./bin/operator-sdk ;\
+	}
+OPERATOR_SDK=$(realpath ./bin/operator-sdk)
+else
+OPERATOR_SDK=$(shell which operator-sdk)
+endif
+
+############################################################
+# images section
+############################################################
+
+operator:
+	docker build . -t ${IMG_OPERATOR} -f build/Dockerfile
+
+runner:
+	docker build . -t ${IMG_RUNNER} -f build/Dockerfile.runner
+
+
+bundle: operator-sdk
+	operator-sdk bundle create ${IMG_BUNDLE} \
+      --channels release-0.1 \
+      --default-channel release-0.1
+
+############################################################
+# publish section
+# prerequisite:
+# docker login quay.io/open-cluster-management with valid credential
+############################################################
+
+publish-operator:
+	docker push ${IMG_OPERATOR}
+
+publish-runner:
+	docker push ${IMG_RUNNER}
+
+publish-bundle:
+	docker push ${IMG_BUNDLE}

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ runner:
 
 
 bundle: operator-sdk
-	operator-sdk bundle create ${IMG_BUNDLE} \
+	${OPERATOR_SDK} bundle create ${IMG_BUNDLE} \
       --channels release-0.1 \
       --default-channel release-0.1
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OS    = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH  = $(shell uname -m | sed 's/x86_64/amd64/')
 OSOPER   = $(shell uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/apple-darwin/' | sed 's/linux/linux-gnu/')
 ARCHOPER = $(shell uname -m )
-_OPERATOR_SDK_VERSION ?= v0.18.0
+_OPERATOR_SDK_VERSION ?= v0.18.2
 
 ############################################################
 # dependency section
@@ -37,17 +37,17 @@ endif
 # images section
 ############################################################
 
-operator:
+build-operator:
 	docker build . -t ${IMG_OPERATOR} -f build/Dockerfile
 
-runner:
+build-runner:
 	docker build . -t ${IMG_RUNNER} -f build/Dockerfile.runner
 
+build-bundle: operator-sdk
+	docker build -f bundle.Dockerfile -t $(IMG_BUNDLE) .
 
-bundle: operator-sdk
-	${OPERATOR_SDK} bundle create ${IMG_BUNDLE} \
-      --channels release-0.1 \
-      --default-channel release-0.1
+validate-bundle: operator-sdk
+	${OPERATOR_SDK} bundle validate $(IMG_BUNDLE)
 
 ############################################################
 # publish section

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=awx-resource-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=release-0.1
+LABEL operators.operatorframework.io.bundle.channel.default.v1=release-0.1
+
+COPY deploy/olm-catalog/awx-resource-operator/manifests /manifests/
+COPY deploy/olm-catalog/awx-resource-operator/metadata /metadata/

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,6 +6,9 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=awx-resource-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=release-0.1
 LABEL operators.operatorframework.io.bundle.channel.default.v1=release-0.1
+LABEL com.redhat.delivery.operator.bundle=true
+LABEL com.redhat.openshift.versions=v4.5,v4.6
+LABEL com.redhat.delivery.backport=true
 
 COPY deploy/olm-catalog/awx-resource-operator/manifests /manifests/
 COPY deploy/olm-catalog/awx-resource-operator/metadata /metadata/

--- a/deploy/olm-catalog/awx-resource-operator/manifests/awx-resource-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/manifests/awx-resource-operator.clusterserviceversion.yaml
@@ -37,6 +37,13 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    categories: "Integration & Delivery,OpenShift Optional"
+    description: The Ansible job operator manages AnsibleJob resources for launching tower job teamplates in Ansible Towers
+    containerImage: quay.io/open-cluster-management/aap-resource-operator:latest
+    certified: 'false'
+    createdAt: 2020-09-12T18:00:00Z
+    repository: https://github.com/ansible/awx-resource-operator/
+    support: Red Hat
   name: awx-resource-operator.v0.1.0
   namespace: placeholder
 spec:
@@ -50,7 +57,7 @@ spec:
   displayName: aap-resource-operator
   icon:
   - base64data: ""
-    mediatype: ""
+    mediatype: "image/jpeg"
   install:
     spec:
       clusterPermissions:
@@ -206,12 +213,9 @@ spec:
   - name: Awx Resource Operator
     url: https://github.com/ansible/awx-resource-operator/
   maintainers:
-  - email: ming@redhat.ocm
-    name: Mike Ng
-  - email: xiangli@redhat.com
-    name: Xiangjing Li
+  - email: ocm-dev@open-cluster-management.io
+    name: Open Cluster Management Project team
   maturity: alpha
   provider:
     name: Red Hat
-    url: https://www.redhat.com/
   version: 0.1.0

--- a/deploy/olm-catalog/awx-resource-operator/manifests/awx-resource-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/manifests/awx-resource-operator.clusterserviceversion.yaml
@@ -1,0 +1,217 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "tower.ansible.com/v1alpha1",
+          "kind": "AnsibleJob",
+          "metadata": {
+            "generateName": "demo-job-",
+            "namespace": "default"
+          },
+          "spec": {
+            "extra_vars": {
+              "cost": 6.88,
+              "ghosts": [
+                "inky",
+                "pinky",
+                "clyde",
+                "sue"
+              ],
+              "is_enable": false,
+              "other_variable": "foo",
+              "pacman": "mrs",
+              "size": 8,
+              "targets_list": [
+                "aaa",
+                "bbb",
+                "ccc"
+              ],
+              "version": "1.23.45"
+            },
+            "job_template_name": "Demo Job Template",
+            "tower_auth_secret": "toweraccess"
+          }
+        }
+      ]
+    capabilities: Basic Install
+  name: awx-resource-operator.v0.1.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: AnsibleJob
+      name: ansiblejobs.tower.ansible.com
+      version: v1alpha1
+  description: Ansible Tower job operator
+  displayName: aap-resource-operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          - rbac.authorization.k8s.io
+          resources:
+          - pods
+          - serviceaccounts
+          - roles
+          - rolebindings
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - tower-resource-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - jobs
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          - jobs
+          verbs:
+          - get
+        - apiGroups:
+          - tower.ansible.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: tower-resource-operator
+      deployments:
+      - name: tower-resource-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: tower-resource-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: tower-resource-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: tower-resource-operator
+                - name: ANSIBLE_GATHERING
+                  value: explicit
+                - name: ANSIBLE_DEBUG_LOGS
+                  value: "True"
+                - name: ANSIBLE_JOB_RUNNER_IMAGE
+                  value: quay.io/open-cluster-management/aap-resource-runner:latest
+                image: quay.io/open-cluster-management/aap-resource-operator:latest
+                imagePullPolicy: Always
+                name: tower-resource-operator
+                resources: {}
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+              serviceAccountName: tower-resource-operator
+              volumes:
+              - emptyDir: {}
+                name: runner
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - Ansilbe Tower
+  - Red Hat
+  links:
+  - name: Awx Resource Operator
+    url: https://github.com/ansible/awx-resource-operator/
+  maintainers:
+  - email: ming@redhat.ocm
+    name: Mike Ng
+  - email: xiangli@redhat.com
+    name: Xiangjing Li
+  maturity: alpha
+  provider:
+    name: Red Hat
+    url: https://www.redhat.com/
+  version: 0.1.0

--- a/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_joblaunch_crd.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ansiblejobs.tower.ansible.com
+spec:
+  group: tower.ansible.com
+  names:
+    kind: AnsibleJob
+    listKind: AnsibleJobList
+    plural: ansiblejobs
+    singular: ansiblejob
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+        description: Schema validation for the Tower Job Launch CRD
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              tower_auth_secret:
+                type: string
+              job_template_name:
+                type: string
+              inventory:
+                type: string
+              extra_vars:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - tower_auth_secret
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/olm-catalog/awx-resource-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/metadata/annotations.yaml
@@ -5,3 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: awx-resource-operator
+  com.redhat.delivery.operator.bundle: true
+  com.redhat.openshift.versions: v4.5,v4.6
+  com.redhat.delivery.backport: true

--- a/deploy/olm-catalog/awx-resource-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: release-0.1
+  operators.operatorframework.io.bundle.channels.v1: release-0.1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: awx-resource-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: tower-resource-operator
           # Replace this with the built image name
-          image: "matburt/tower-resource-operator:0.1.0"
+          image: "quay.io/open-cluster-management/aap-resource-operator:latest"
           imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
@@ -37,7 +37,7 @@ spec:
               value: "True"
             - name: ANSIBLE_JOB_RUNNER_IMAGE
               # Replace this with the job runner built image name
-              value: "matburt/operator-job-run:latest"
+              value: "quay.io/open-cluster-management/aap-resource-runner:latest"
       volumes:
         - name: runner
           emptyDir: {}

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -146,7 +146,7 @@ spec:
       containers:
         - name: tower-resource-operator
           # Replace this with the built image name
-          image: "matburt/tower-resource-operator:0.1.0"
+          image: "quay.io/open-cluster-management/aap-resource-operator:latest"
           imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
@@ -165,7 +165,7 @@ spec:
               value: "True"
             - name: ANSIBLE_JOB_RUNNER_IMAGE
               # Replace this with the job runner built image name
-              value: "matburt/operator-job-run:latest"
+              value: "quay.io/open-cluster-management/aap-resource-runner:latest"
       volumes:
         - name: runner
           emptyDir: {}

--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -1,8 +1,110 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: tower-resource-operator
+  namespace: "{{ meta.namespace }}"
+rules:
+- apiGroups:
+  - ""
+  - rbac.authorization.k8s.io
+  resources:
+  - pods
+  - serviceaccounts
+  - roles
+  - rolebindings
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - tower-resource-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - jobs
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  - jobs
+  verbs:
+  - get
+- apiGroups:
+  - tower.ansible.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-    name: tower-resource-operator
-    namespace: "{{ meta.namespace }}"
+  name: tower-resource-operator
+  namespace: "{{ meta.namespace }}"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,8 +116,9 @@ subjects:
   name: tower-resource-operator
   namespace: "{{ meta.namespace }}"
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: tower-resource-operator
+  namespace: "{{ meta.namespace }}"
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: batch/v1


### PR DESCRIPTION
change list:

1. Makefile - For building operator/ runner/ bundle images

2. bundle.Dockerfile -  The dockerfile for building bundle image

3. operator bundle package files - operator CSV, CRD and meta annotation.yaml

4.  when create k8s runner job, we used to create a service account and bind it to the existing operator cluster role. It turns out not working if the operator is installed by operator CSV bundle, where the operator cluster role has been renamed by adding a  random string suffix.

The fix is to create a new role and bind the service account to the new role when the k8s runner job is created. Thus the k8s runner job  won't reply on operator cluster role any more.

 