### PR TITLE
append to bundle job template crd

### DIFF
--- a/deploy/olm-catalog/awx-resource-operator/manifests/awx-resource-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/manifests/awx-resource-operator.clusterserviceversion.yaml
@@ -34,6 +34,21 @@ metadata:
             "job_template_name": "Demo Job Template",
             "tower_auth_secret": "toweraccess"
           }
+        },
+        {
+          "apiVersion": "tower.ansible.com/v1alpha1",
+          "kind": "JobTemplate",
+          "metadata": {
+            "name": "examplejobtemplate",
+            "namespace": "awx"
+          },
+          "spec": {
+            "job_template_inventory": "Demo Inventory",
+            "job_template_name": "ExampleJobTemplate",
+            "job_template_playbook": "hello_world.yml",
+            "job_template_project": "Demo Project",
+            "tower_auth_secret": "toweraccess"
+          }
         }
       ]
     capabilities: Basic Install
@@ -41,7 +56,7 @@ metadata:
     description: The Ansible job operator manages AnsibleJob resources for launching tower job teamplates in Ansible Towers
     containerImage: quay.io/open-cluster-management/aap-resource-operator:latest
     certified: 'false'
-    createdAt: 2020-09-12T18:00:00Z
+    createdAt: 2020-09-15T18:00:00Z
     repository: https://github.com/ansible/awx-resource-operator/
     support: Red Hat
   name: awx-resource-operator.v0.1.0
@@ -52,6 +67,9 @@ spec:
     owned:
     - kind: AnsibleJob
       name: ansiblejobs.tower.ansible.com
+      version: v1alpha1
+    - kind: JobTemplate
+      name: jobtemplates.tower.ansible.com
       version: v1alpha1
   description: Ansible Tower job operator
   displayName: aap-resource-operator

--- a/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_jobtemplates_crd.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_jobtemplates_crd.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: jobtemplates.tower.ansible.com
+spec:
+  group: tower.ansible.com
+  names:
+    kind: JobTemplate
+    listKind: JobTemplateList
+    plural: jobtemplates
+    singular: jobtemplate
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          description: Schema validation for the Tower Resource CRD
+          properties:
+            spec:
+              type: object
+              properties:
+                tower_auth_secret:
+                  type: string
+                job_template_name:
+                  type: string
+                job_template_project:
+                  type: string
+                job_template_playbook:
+                  type: string
+                job_template_inventory:
+                  type: string
+          required:
+            - tower_auth_secret


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

The job template crd has to be bundled in ansible job operator CSV. Or the operator will fail to run after a while.