### PR TITLE
Update AnsibleJob CRD to require template name. Update AnsibleJob status with inventory

### DIFF
--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -38,6 +38,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
             required:
             - tower_auth_secret
+            - job_template_name
             type: object
     served: true
     storage: true

--- a/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_joblaunch_crd.yaml
@@ -38,6 +38,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
             required:
             - tower_auth_secret
+            - job_template_name
             type: object
     served: true
     storage: true

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -251,6 +251,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
             required:
             - tower_auth_secret
+            - job_template_name
             type: object
     served: true
     storage: true

--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -52,6 +52,7 @@
         message: "Monitor the K8s job status and log for more details"
         namespacedName: "{{meta.namespace+'/'+meta.name}}"
         env:
+          inventory: "{{ inventory | default(omit) }}"
           secretNamespacedName: "{{meta.namespace+'/'+tower_auth_secret}}"
           templateName: "{{ job_template_name }}"
           verifySSL: false


### PR DESCRIPTION
The first change is to update AnsibleJob CRD to require template name. This is useful for letting K8s do the validation upfront which saves some operator processing.

The second change is to update AnsibleJob status with inventory value. This value is useful to show what was actually sent to the Tower. For example, after the AnsibleJob is created and a request is sent to the AWX/Tower server, users can update the AnsibleJob values under `spec` but that's not going to change the values under `status` which are the values that were actually used in the request. 