### PR TITLE
release-0.1 ONLY add hack hosts file

### DIFF
--- a/build/Dockerfile.runner
+++ b/build/Dockerfile.runner
@@ -1,6 +1,7 @@
 FROM registry.redhat.io/ansible-tower-37/ansible-runner-rhel7:1.4.6-1.1594641921
 ENV ANSIBLE_ROLES_PATH ${HOME}/roles
 
+COPY hack/hosts /runner/inventory
 COPY vendor /tmp/vendor
 COPY requirements.txt /tmp/requirements.txt
 

--- a/hack/hosts
+++ b/hack/hosts
@@ -1,0 +1,1 @@
+localhost


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

This is for `release-0.1` branch only. It seems like `ansible-runner-rhel7:1.4.6-1.1594641921` base image doesn't have the `/runner/inventory/hosts` file that the runner needs.