### PR TITLE
release-0.1 ONLY use localost for running the ansible-runner

### DIFF
--- a/build/Dockerfile.runner
+++ b/build/Dockerfile.runner
@@ -1,7 +1,6 @@
 FROM registry.redhat.io/ansible-tower-37/ansible-runner-rhel7:1.4.6-1.1594641921
 ENV ANSIBLE_ROLES_PATH ${HOME}/roles
 
-COPY hack/hosts /runner/inventory
 COPY vendor /tmp/vendor
 COPY requirements.txt /tmp/requirements.txt
 
@@ -14,4 +13,4 @@ RUN ansible-galaxy collection install /tmp/vendor/galaxy.ansible.com/awx/awx/awx
 RUN pip3 install -r /tmp/requirements.txt
 
 COPY roles/job_runner ${HOME}/roles/job_runner
-CMD ["ansible-runner", "-r", "job_runner", "run", "/runner"]
+CMD ["ansible-runner", "--hosts", "localhost", "-r", "job_runner", "run", "/runner"]

--- a/hack/hosts
+++ b/hack/hosts
@@ -1,1 +1,0 @@
-localhost


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

The `COPY` command wasn't able to create the hosts file under `/runner/inventory`. 

Since the ansible-runner is always exec in the container with the context of localhost, pass in the `--hosts localhost` as part of the param instead of relying of a static `hosts` file that contains the content `localhost`