### PR TITLE
release-0.1 ONLY use python3 for ansible interpreter

### DIFF
--- a/roles/job_runner/vars/main.yml
+++ b/roles/job_runner/vars/main.yml
@@ -1,0 +1,2 @@
+---
+ansible_python_interpreter: '/usr/bin/python3'


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

by default the job runner uses python2 this forces to use python3 where the python modules dependencies are installed at.