### PR TITLE
V1beta1crd

### DIFF
--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -1,22 +1,20 @@
 ---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: ansiblejobs.tower.ansible.com
-spec:
-  group: tower.ansible.com
-  names:
-    kind: AnsibleJob
-    listKind: AnsibleJobList
-    plural: ansiblejobs
-    singular: ansiblejob
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
+  apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: ansiblejobs.tower.ansible.com
+  spec:
+    group: tower.ansible.com
+    names:
+      kind: AnsibleJob
+      listKind: AnsibleJobList
+      plural: ansiblejobs
+      singular: ansiblejob
+    scope: Namespaced
+    subresources:
+      status: {}
+    validation:
       openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
         description: Schema validation for the Tower Job Launch CRD
         properties:
           apiVersion:
@@ -27,20 +25,23 @@ spec:
             type: object
           spec:
             properties:
-              tower_auth_secret:
-                type: string
-              job_template_name:
-                type: string
-              inventory:
-                type: string
               extra_vars:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              inventory:
+                type: string
+              job_template_name:
+                type: string
+              tower_auth_secret:
+                type: string
             required:
             - tower_auth_secret
             - job_template_name
             type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    version: v1alpha1
+    versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -1,47 +1,47 @@
 ---
-  apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    name: ansiblejobs.tower.ansible.com
-  spec:
-    group: tower.ansible.com
-    names:
-      kind: AnsibleJob
-      listKind: AnsibleJobList
-      plural: ansiblejobs
-      singular: ansiblejob
-    scope: Namespaced
-    subresources:
-      status: {}
-    validation:
-      openAPIV3Schema:
-        description: Schema validation for the Tower Job Launch CRD
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              extra_vars:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              inventory:
-                type: string
-              job_template_name:
-                type: string
-              tower_auth_secret:
-                type: string
-            required:
-            - tower_auth_secret
-            - job_template_name
-            type: object
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    version: v1alpha1
-    versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ansiblejobs.tower.ansible.com
+spec:
+  group: tower.ansible.com
+  names:
+    kind: AnsibleJob
+    listKind: AnsibleJobList
+    plural: ansiblejobs
+    singular: ansiblejob
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema validation for the Tower Job Launch CRD
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            extra_vars:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            inventory:
+              type: string
+            job_template_name:
+              type: string
+            tower_auth_secret:
+              type: string
+          required:
+          - tower_auth_secret
+          - job_template_name
+          type: object
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/crds/tower.ansible.com_jobtemplates_crd.yaml
+++ b/deploy/crds/tower.ansible.com_jobtemplates_crd.yaml
@@ -1,40 +1,41 @@
 ---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: jobtemplates.tower.ansible.com
-spec:
-  group: tower.ansible.com
-  names:
-    kind: JobTemplate
-    listKind: JobTemplateList
-    plural: jobtemplates
-    singular: jobtemplate
-  scope: Namespaced
-  versions:
+  apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: jobtemplates.tower.ansible.com
+  spec:
+    group: tower.ansible.com
+    names:
+      kind: JobTemplate
+      listKind: JobTemplateList
+      plural: jobtemplates
+      singular: jobtemplate
+    scope: Namespaced
+    subresources:
+      status: {}
+    validation:
+      openAPIV3Schema:
+        description: Schema validation for the Tower Resource CRD
+        properties:
+          spec:
+            properties:
+              job_template_inventory:
+                type: string
+              job_template_name:
+                type: string
+              job_template_playbook:
+                type: string
+              job_template_project:
+                type: string
+              tower_auth_secret:
+                type: string
+            type: object
+        required:
+        - tower_auth_secret
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    version: v1alpha1
+    versions:
     - name: v1alpha1
       served: true
       storage: true
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          description: Schema validation for the Tower Resource CRD
-          properties:
-            spec:
-              type: object
-              properties:
-                tower_auth_secret:
-                  type: string
-                job_template_name:
-                  type: string
-                job_template_project:
-                  type: string
-                job_template_playbook:
-                  type: string
-                job_template_inventory:
-                  type: string
-          required:
-            - tower_auth_secret

--- a/deploy/crds/tower.ansible.com_jobtemplates_crd.yaml
+++ b/deploy/crds/tower.ansible.com_jobtemplates_crd.yaml
@@ -1,41 +1,41 @@
 ---
-  apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    name: jobtemplates.tower.ansible.com
-  spec:
-    group: tower.ansible.com
-    names:
-      kind: JobTemplate
-      listKind: JobTemplateList
-      plural: jobtemplates
-      singular: jobtemplate
-    scope: Namespaced
-    subresources:
-      status: {}
-    validation:
-      openAPIV3Schema:
-        description: Schema validation for the Tower Resource CRD
-        properties:
-          spec:
-            properties:
-              job_template_inventory:
-                type: string
-              job_template_name:
-                type: string
-              job_template_playbook:
-                type: string
-              job_template_project:
-                type: string
-              tower_auth_secret:
-                type: string
-            type: object
-        required:
-        - tower_auth_secret
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    version: v1alpha1
-    versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: jobtemplates.tower.ansible.com
+spec:
+  group: tower.ansible.com
+  names:
+    kind: JobTemplate
+    listKind: JobTemplateList
+    plural: jobtemplates
+    singular: jobtemplate
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema validation for the Tower Resource CRD
+      properties:
+        spec:
+          properties:
+            job_template_inventory:
+              type: string
+            job_template_name:
+              type: string
+            job_template_playbook:
+              type: string
+            job_template_project:
+              type: string
+            tower_auth_secret:
+              type: string
+          type: object
+      required:
+      - tower_auth_secret
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_joblaunch_crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: ansiblejobs.tower.ansible.com
@@ -11,36 +11,37 @@ spec:
     plural: ansiblejobs
     singular: ansiblejob
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema validation for the Tower Job Launch CRD
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            extra_vars:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            inventory:
+              type: string
+            job_template_name:
+              type: string
+            tower_auth_secret:
+              type: string
+          required:
+          - tower_auth_secret
+          - job_template_name
+          type: object
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-        description: Schema validation for the Tower Job Launch CRD
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              tower_auth_secret:
-                type: string
-              job_template_name:
-                type: string
-              inventory:
-                type: string
-              extra_vars:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-            required:
-            - tower_auth_secret
-            - job_template_name
-            type: object
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_jobtemplates_crd.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/manifests/tower.ansible.com_jobtemplates_crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: jobtemplates.tower.ansible.com
@@ -11,30 +11,31 @@ spec:
     plural: jobtemplates
     singular: jobtemplate
   scope: Namespaced
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          description: Schema validation for the Tower Resource CRD
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema validation for the Tower Resource CRD
+      properties:
+        spec:
           properties:
-            spec:
-              type: object
-              properties:
-                tower_auth_secret:
-                  type: string
-                job_template_name:
-                  type: string
-                job_template_project:
-                  type: string
-                job_template_playbook:
-                  type: string
-                job_template_inventory:
-                  type: string
-          required:
-            - tower_auth_secret
+            job_template_inventory:
+              type: string
+            job_template_name:
+              type: string
+            job_template_playbook:
+              type: string
+            job_template_project:
+              type: string
+            tower_auth_secret:
+              type: string
+          type: object
+      required:
+      - tower_auth_secret
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -171,65 +171,64 @@ spec:
           emptyDir: {}
 
 ---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: jobtemplates.tower.ansible.com
-spec:
-  group: tower.ansible.com
-  names:
-    kind: JobTemplate
-    listKind: JobTemplateList
-    plural: jobtemplates
-    singular: jobtemplate
-  scope: Namespaced
-  versions:
+  apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: jobtemplates.tower.ansible.com
+  spec:
+    group: tower.ansible.com
+    names:
+      kind: JobTemplate
+      listKind: JobTemplateList
+      plural: jobtemplates
+      singular: jobtemplate
+    scope: Namespaced
+    subresources:
+      status: {}
+    validation:
+      openAPIV3Schema:
+        description: Schema validation for the Tower Resource CRD
+        properties:
+          spec:
+            properties:
+              job_template_inventory:
+                type: string
+              job_template_name:
+                type: string
+              job_template_playbook:
+                type: string
+              job_template_project:
+                type: string
+              tower_auth_secret:
+                type: string
+            type: object
+        required:
+        - tower_auth_secret
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    version: v1alpha1
+    versions:
     - name: v1alpha1
       served: true
       storage: true
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          description: Schema validation for the Tower Resource CRD
-          properties:
-            spec:
-              type: object
-              properties:
-                tower_auth_secret:
-                  type: string
-                job_template_name:
-                  type: string
-                job_template_project:
-                  type: string
-                job_template_playbook:
-                  type: string
-                job_template_inventory:
-                  type: string
-          required:
-            - tower_auth_secret
 
 ---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: ansiblejobs.tower.ansible.com
-spec:
-  group: tower.ansible.com
-  names:
-    kind: AnsibleJob
-    listKind: AnsibleJobList
-    plural: ansiblejobs
-    singular: ansiblejob
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
+  apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: ansiblejobs.tower.ansible.com
+  spec:
+    group: tower.ansible.com
+    names:
+      kind: AnsibleJob
+      listKind: AnsibleJobList
+      plural: ansiblejobs
+      singular: ansiblejob
+    scope: Namespaced
+    subresources:
+      status: {}
+    validation:
       openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
         description: Schema validation for the Tower Job Launch CRD
         properties:
           apiVersion:
@@ -240,20 +239,23 @@ spec:
             type: object
           spec:
             properties:
-              tower_auth_secret:
-                type: string
-              job_template_name:
-                type: string
-              inventory:
-                type: string
               extra_vars:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              inventory:
+                type: string
+              job_template_name:
+                type: string
+              tower_auth_secret:
+                type: string
             required:
             - tower_auth_secret
             - job_template_name
             type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    version: v1alpha1
+    versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -171,91 +171,91 @@ spec:
           emptyDir: {}
 
 ---
-  apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    name: jobtemplates.tower.ansible.com
-  spec:
-    group: tower.ansible.com
-    names:
-      kind: JobTemplate
-      listKind: JobTemplateList
-      plural: jobtemplates
-      singular: jobtemplate
-    scope: Namespaced
-    subresources:
-      status: {}
-    validation:
-      openAPIV3Schema:
-        description: Schema validation for the Tower Resource CRD
-        properties:
-          spec:
-            properties:
-              job_template_inventory:
-                type: string
-              job_template_name:
-                type: string
-              job_template_playbook:
-                type: string
-              job_template_project:
-                type: string
-              tower_auth_secret:
-                type: string
-            type: object
-        required:
-        - tower_auth_secret
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    version: v1alpha1
-    versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: jobtemplates.tower.ansible.com
+spec:
+  group: tower.ansible.com
+  names:
+    kind: JobTemplate
+    listKind: JobTemplateList
+    plural: jobtemplates
+    singular: jobtemplate
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema validation for the Tower Resource CRD
+      properties:
+        spec:
+          properties:
+            job_template_inventory:
+              type: string
+            job_template_name:
+              type: string
+            job_template_playbook:
+              type: string
+            job_template_project:
+              type: string
+            tower_auth_secret:
+              type: string
+          type: object
+      required:
+      - tower_auth_secret
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
 
 ---
-  apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    name: ansiblejobs.tower.ansible.com
-  spec:
-    group: tower.ansible.com
-    names:
-      kind: AnsibleJob
-      listKind: AnsibleJobList
-      plural: ansiblejobs
-      singular: ansiblejob
-    scope: Namespaced
-    subresources:
-      status: {}
-    validation:
-      openAPIV3Schema:
-        description: Schema validation for the Tower Job Launch CRD
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              extra_vars:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              inventory:
-                type: string
-              job_template_name:
-                type: string
-              tower_auth_secret:
-                type: string
-            required:
-            - tower_auth_secret
-            - job_template_name
-            type: object
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    version: v1alpha1
-    versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ansiblejobs.tower.ansible.com
+spec:
+  group: tower.ansible.com
+  names:
+    kind: AnsibleJob
+    listKind: AnsibleJobList
+    plural: ansiblejobs
+    singular: ansiblejob
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema validation for the Tower Job Launch CRD
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            extra_vars:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            inventory:
+              type: string
+            job_template_name:
+              type: string
+            tower_auth_secret:
+              type: string
+          required:
+          - tower_auth_secret
+          - job_template_name
+          type: object
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
The ansible operator was failing on a backport test on OCP 4.2-4.4 with this error
```
time="2020-09-22T20:14:45Z" level=fatal msg="permissive mode disabled" error="error loading manifests from directory: [error checking provided apis in bundle : error decoding CRD: no kind \"CustomResourceDefinition\" is registered for version \"apiextensions.k8s.io/v1\" in scheme \"pkg/registry/bundle.go:15\", error adding operator bundle : error decoding CRD: no kind \"CustomResourceDefinition\" is registered for version \"apiextensions.k8s.io/v1\" in scheme \"pkg/registry/bundle.go:15\", error loading package into db: [FOREIGN KEY constraint failed, no default channel specified for awx-resource-operator]]"
exit status 1
```

The fix is to convert the two CRDs apiVersion from `apiVersion: apiextensions.k8s.io/v1` to `apiextensions.k8s.io/v1beta1`. 
```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
```
Note the `ansiblejobs.tower.ansible.com` and `jobtemplates.tower.ansible.com` versions are still remained as `v1alpha1`