### PR TITLE
catch the exception when calling wait tower job and stamp the status with error

### DIFF
--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -51,10 +51,21 @@
         status: "{{ job.status }}"
         url: "{{lookup('env', 'TOWER_HOST') + '/#/jobs/playbook/' + (job.id|string)}}"
 
-- name: Wait for job
-  tower_job_wait:
-    job_id: "{{ job.id }}"
-  register: job_result
+- name: Wait for the tower job if error update AnsibleJob status then end play
+  block:
+    - tower_job_wait:
+        job_id: "{{ job.id }}"
+      register: job_result
+  rescue:
+    - k8s_status:
+        api_version: tower.ansible.com/v1alpha1
+        kind: AnsibleJob
+        name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
+        namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+        status:
+          ansibleJobResult:
+            status: "error"
+    - meta: end_play
 
 - name: Update AnsibleJob status with Tower job result
   k8s_status:


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

When calling the `tower_job_wait` it seems to throw an exception if the Tower Job instance is in a fail state. 
This PR is to make sure we catch that exception and update the `AnsibleJob.status.ansibleJobResult.status` with `error`
so that it doesn't say `pending` which gives an illusion that tower is still working on it.

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: tower_cli.exceptions.JobFailure: Job failed.
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1601665637.3796034-100-110247515530561/AnsiballZ_tower_job_wait.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1601665637.3796034-100-110247515530561/AnsiballZ_tower_job_wait.py\", line 94, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1601665637.3796034-100-110247515530561/AnsiballZ_tower_job_wait.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.web_infrastructure.ansible_tower.tower_job_wait', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_tower_job_wait_payload_c0okjsws/ansible_tower_job_wait_payload.zip/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py\", line 149, in <module>\n  File \"/tmp/ansible_tower_job_wait_payload_c0okjsws/ansible_tower_job_wait_payload.zip/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py\", line 127, in main\n  File \"/usr/local/lib/python3.6/site-packages/tower_cli/models/base.py\", line 868, in monitor\n    self.wait(pk, exit_on=['running', 'successful'], outfile=outfile)\n  File \"/usr/local/lib/python3.6/site-packages/tower_cli/models/base.py\", line 980, in wait\n    raise exc.JobFailure('Job failed.')\ntower_cli.exceptions.JobFailure: Job failed.\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```