### PR TITLE
Use v1 extensions because v1beta1 is being removed

### DIFF
--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ansiblejobs.tower.ansible.com

--- a/deploy/crds/tower.ansible.com_jobtemplates_crd.yaml
+++ b/deploy/crds/tower.ansible.com_jobtemplates_crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: jobtemplates.tower.ansible.com

--- a/deploy/olm-catalog/awx-resource-operator/0.1.0/manifests/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/0.1.0/manifests/tower.ansible.com_joblaunch_crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ansiblejobs.tower.ansible.com

--- a/deploy/olm-catalog/awx-resource-operator/0.1.0/manifests/tower.ansible.com_jobtemplates_crd.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/0.1.0/manifests/tower.ansible.com_jobtemplates_crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: jobtemplates.tower.ansible.com

--- a/deploy/olm-catalog/awx-resource-operator/0.1.1/manifests/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/0.1.1/manifests/tower.ansible.com_joblaunch_crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ansiblejobs.tower.ansible.com

--- a/deploy/olm-catalog/awx-resource-operator/0.1.1/manifests/tower.ansible.com_jobtemplates_crd.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/0.1.1/manifests/tower.ansible.com_jobtemplates_crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: jobtemplates.tower.ansible.com

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -171,7 +171,7 @@ spec:
           emptyDir: {}
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: jobtemplates.tower.ansible.com
@@ -185,41 +185,42 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: Schema validation for the Tower Job Template CRD
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            job_template_inventory:
-              type: string
-            job_template_name:
-              type: string
-            job_template_playbook:
-              type: string
-            job_template_project:
-              type: string
-            tower_auth_secret:
-              type: string
-          required:
-          - tower_auth_secret
-          type: object
-      type: object
-      x-kubernetes-preserve-unknown-fields: true
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: Schema validation for the Tower Job Template CRD
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              job_template_inventory:
+                type: string
+              job_template_name:
+                type: string
+              job_template_playbook:
+                type: string
+              job_template_project:
+                type: string
+              tower_auth_secret:
+                type: string
+            required:
+            - tower_auth_secret
+            type: object
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1
+
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ansiblejobs.tower.ansible.com
@@ -233,35 +234,36 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: Schema validation for the Tower Job Launch CRD
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            extra_vars:
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            inventory:
-              type: string
-            job_template_name:
-              type: string
-            tower_auth_secret:
-              type: string
-          required:
-          - tower_auth_secret
-          - job_template_name
-          type: object
-      type: object
-      x-kubernetes-preserve-unknown-fields: true
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+
+    schema:
+      openAPIV3Schema:
+        description: Schema validation for the Tower Job Launch CRD
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              extra_vars:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              inventory:
+                type: string
+              job_template_name:
+                type: string
+              tower_auth_secret:
+                type: string
+            required:
+            - tower_auth_secret
+            - job_template_name
+            type: object
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1


### PR DESCRIPTION
To remain compatible with Kubernetes 1.22 and Openshift 4.9, we need to start using the `extensions/v1` API as the `extensions/v1beta1` is being removed.  


> All beta Ingress APIs (the extensions/v1beta1 and networking.k8s.io/v1beta1 API versions)

>The beta CustomResourceDefinition API (apiextensions.k8s.io/v1beta1)

Context: https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/