### PR TITLE
Properly nest subresources for CRD & do not use clusterPermissions in CSV

### DIFF
--- a/ansible/templates/joblaunch_crd.yml.j2
+++ b/ansible/templates/joblaunch_crd.yml.j2
@@ -11,13 +11,12 @@ spec:
     plural: ansiblejobs
     singular: ansiblejob
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
     served: true
     storage: true
-
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: Schema validation for the Tower Job Launch CRD

--- a/ansible/templates/jobtemplates_crd.yml.j2
+++ b/ansible/templates/jobtemplates_crd.yml.j2
@@ -11,12 +11,12 @@ spec:
     plural: jobtemplates
     singular: jobtemplate
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: Schema validation for the Tower Job Template CRD

--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -11,13 +11,12 @@ spec:
     plural: ansiblejobs
     singular: ansiblejob
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
     served: true
     storage: true
-
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: Schema validation for the Tower Job Launch CRD

--- a/deploy/crds/tower.ansible.com_jobtemplates_crd.yaml
+++ b/deploy/crds/tower.ansible.com_jobtemplates_crd.yaml
@@ -11,12 +11,12 @@ spec:
     plural: jobtemplates
     singular: jobtemplate
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: Schema validation for the Tower Job Template CRD

--- a/deploy/olm-catalog/awx-resource-operator/0.1.1/manifests/awx-resource-operator.0.1.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/awx-resource-operator/0.1.1/manifests/awx-resource-operator.0.1.1.clusterserviceversion.yaml
@@ -80,7 +80,7 @@ spec:
     mediatype: image/svg+xml
   install:
     spec:
-      clusterPermissions:
+      permissions:
       - rules:
         - apiGroups:
           - ""

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -136,13 +136,12 @@ spec:
     plural: ansiblejobs
     singular: ansiblejob
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
     served: true
     storage: true
-
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: Schema validation for the Tower Job Launch CRD
@@ -185,12 +184,12 @@ spec:
     plural: jobtemplates
     singular: jobtemplate
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: Schema validation for the Tower Job Template CRD


### PR DESCRIPTION
For OLM to create the proper roles from the CSV, we need to use `Permissions`, not `clusterPermissions`.  

Also, to enable the ability to set statuses on a CRD, `subresources` needs to be nested under `version:`