### PR TITLE
Rename operator image name to make it unique from pulp & awx

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,7 +20,7 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
-      - name: manager
+      - name: awx-resource-manager
         args:
         - "--health-probe-bind-address=:6789"
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -7,14 +7,14 @@ spec:
   template:
     spec:
       containers:
-      - name: manager
+      - name: awx-resource-manager
         args:
         - "--config=controller_manager_config.yaml"
         volumeMounts:
-        - name: manager-config
+        - name: awx-resource-manager-config
           mountPath: /controller_manager_config.yaml
           subPath: controller_manager_config.yaml
       volumes:
-      - name: manager-config
+      - name: awx-resource-manager-config
         configMap:
-          name: manager-config
+          name: awx-resource-manager-config

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,6 +5,6 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: manager-config
+- name: awx-resource-manager-config
   files:
   - controller_manager_config.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --leader-elect
         - --leader-election-id=awx-resource-operator
         image: controller:latest
-        name: manager
+        name: awx-resource-manager
         env:
         - name: ANSIBLE_GATHERING
           value: explicit

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: manager-role
+  name: awx-resource-manager-role
 rules:
   ##
   ## Base operator rules

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: manager-rolebinding
+  name: awx-resource-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: manager-role
+  name: awx-resource-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/config/testing/debug_logs_patch.yaml
+++ b/config/testing/debug_logs_patch.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-resource-manager
           env:
             - name: ANSIBLE_DEBUG_LOGS
               value: "TRUE"

--- a/config/testing/manager_image.yaml
+++ b/config/testing/manager_image.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-resource-manager
           image: testing

--- a/config/testing/pull_policy/Always.yaml
+++ b/config/testing/pull_policy/Always.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-resource-manager
           imagePullPolicy: Always

--- a/config/testing/pull_policy/IfNotPresent.yaml
+++ b/config/testing/pull_policy/IfNotPresent.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-resource-manager
           imagePullPolicy: IfNotPresent

--- a/config/testing/pull_policy/Never.yaml
+++ b/config/testing/pull_policy/Never.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: awx-resource-manager
           imagePullPolicy: Never


### PR DESCRIPTION
When building these operators together in a bundle, the operator image names need to be unique.

I updated the other manager references for consistency, but the only required changes are related to the image name.

Related: 
* https://github.com/pulp/pulp-operator/pull/234
* https://github.com/ansible/awx-operator/pull/617 

Signed-off-by: Christian M. Adams <chadams@redhat.com>