### PR TITLE
Minor resource description updates in CSV

### DIFF
--- a/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
@@ -15,7 +15,18 @@ metadata:
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Launch a new job via awx
+      displayName: AWX job
+      kind: AnsibleJob
+      name: ansiblejobs.tower.ansible.com
+      version: v1alpha1
+    - description: Define a new job template in awx
+      displayName: AWX job template
+      kind: JobTemplate
+      name: jobtemplates.tower.ansible.com
+      version: v1alpha1
   description: The Ansible Automation Platform Resource Operator manages launching
     Ansible Jobs and Workflows.
   displayName: AWX Resource Operator


### PR DESCRIPTION
When we did the operator-sdk upgrade, some of the descriptions for resources got auto-populated, this was one of those.