### PR TITLE
Fix ServiceAccount name re: SDK upgrade rename

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: awx-resource-operator-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: awx-resource-operator-
+namePrefix: resource-operator-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -8,7 +8,7 @@ spec:
   ttlSecondsAfterFinished: 3600
   template:
     spec:
-      serviceAccountName: awx-resource-operator-controller-manager
+      serviceAccountName: resource-operator-controller-manager
       containers:
         - name: "{{ ansible_operator_meta.name }}"
           image: "{{ _runner_image }}"


### PR DESCRIPTION
The SA name was overlooked during this rename: https://github.com/ansible/awx-resource-operator/pull/57

As a result, permission errors like the following are seen when reconciling AnsibleJob CR's.  


```
kubectl -n almng-test-ns describe job.batch/prehook-test-3-cb456a
...
Warning  FailedCreate  41s (x5 over 3m11s)  job-controller  Error creating: pods "prehook-test-3-cb456a-" is forbidden: error looking up service account almng-test-ns/awx-resource-operator-controller-manager: serviceaccount "awx-resource-operator-controller-manager" not found
```

This patch corrects the name.  