### PR TITLE
Create SA and roles to be used to create pod to run job in

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -93,13 +93,13 @@ rules:
 #+kubebuilder:scaffold:rules
 
 ##
-## Rules needed for starting k8s runner job
+## Rules needed for managing k8s runner job
 ##
 
   - apiGroups:
     - apps
     resourceNames:
-    - tower-resource-operator
+    - resource-operator-controller-manager
     resources:
     - deployments/finalizers
     verbs:

--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -46,10 +46,15 @@
   set_fact:
     _runner_image: "{{ _custom_runner_image | default(lookup('env', 'RELATED_IMAGE_ANSIBLE_JOB_RUNNER_IMAGE')) }}"
 
+- name: Create ServiceAccount to run pod with if it does not exist
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'service_account.yml.j2') }}"
+
 - name: Start K8s Runner Job
   k8s:
     state: present
-    definition: "{{ lookup('template', 'job_definition.yml') }}"
+    definition: "{{ lookup('template', 'job_definition.yml.j2') }}"
 
 - name: Update AnsibleJob status with K8s job info
   k8s_status:

--- a/roles/job/templates/job_definition.yml.j2
+++ b/roles/job/templates/job_definition.yml.j2
@@ -8,7 +8,7 @@ spec:
   ttlSecondsAfterFinished: 3600
   template:
     spec:
-      serviceAccountName: resource-operator-controller-manager
+      serviceAccountName: resource-operator-controller-manager-job
       containers:
         - name: "{{ ansible_operator_meta.name }}"
           image: "{{ _runner_image }}"

--- a/roles/job/templates/service_account.yml.j2
+++ b/roles/job/templates/service_account.yml.j2
@@ -1,0 +1,116 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: resource-operator-controller-manager-job
+  namespace: "{{ ansible_operator_meta.namespace }}"
+rules:
+- apiGroups:
+  - ""
+  - rbac.authorization.k8s.io
+  resources:
+  - pods
+  - serviceaccounts
+  - roles
+  - rolebindings
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - jobs
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  - jobs
+  verbs:
+  - get
+- apiGroups:
+  - tower.ansible.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: resource-operator-controller-manager-job
+  namespace: "{{ ansible_operator_meta.namespace }}"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: resource-operator-controller-manager-job
+  namespace: "{{ ansible_operator_meta.namespace }}"
+subjects:
+- kind: ServiceAccount
+  name: resource-operator-controller-manager-job
+  namespace: "{{ ansible_operator_meta.namespace }}"
+roleRef:
+  kind: Role
+  name: resource-operator-controller-manager-job
+  namespace: "{{ ansible_operator_meta.namespace }}"
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This makes it so that ansible jobs can be run from namespace other than the on the operator is installed on (for cluster-scoped operator installations)

I removed these during the operator-sdk upgrade to v1.12 to be conservative about permissions and also because I didn't understand at the time what their purpose was.  It is clear now that they are needed to successfully start pods from namespaces other than the one the operator is installed in. 
