### PR TITLE
Add isFinished status and do not retry finished jobs if the job is deleted

### DIFF
--- a/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
+++ b/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
@@ -32,14 +32,17 @@ spec:
                 type: string
               job_template_name:
                 type: string
-              tower_auth_secret:
-                type: string
               runner_image:
                 type: string
                 description: Runner image used when running jobs
               runner_version:
                 type: string
                 description: Runner image version used when running jobs
+              tower_auth_secret:
+                type: string
+              job_ttl:
+                description: Time to live for k8s job object after the playbook run has finished
+                type: integer
             required:
             - tower_auth_secret
             - job_template_name

--- a/roles/job/defaults/main.yml
+++ b/roles/job/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 # defaults file for job
+
+job_ttl: 3600
+backoff_limit: 1

--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -1,13 +1,5 @@
 ---
 
-- name: Read AnsibleJob info
-  k8s_info:
-    api_version: tower.ansible.com/v1alpha1
-    kind: AnsibleJob
-    name: "{{ ansible_operator_meta.name }}"
-    namespace: "{{ ansible_operator_meta.namespace }}"
-  register: ansiblejob_info
-
 - name: Read K8s job info
   k8s_info:
     kind: Job
@@ -27,6 +19,14 @@
   when:
     - k8s_job['resources'][0]['status']['succeeded'] is defined
     - k8s_job['resources'][0]['status']['succeeded'] == 1
+
+- name: Read AnsibleJob info
+  k8s_info:
+    api_version: tower.ansible.com/v1alpha1
+    kind: AnsibleJob
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: ansiblejob_info
 
 - name: End play early is AnsibleJob has already finished
   meta: end_play

--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Read AnsibleJob info
+  k8s_info:
+    api_version: tower.ansible.com/v1alpha1
+    kind: AnsibleJob
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: ansiblejob_info
+
 - name: Read K8s job info
   k8s_info:
     kind: Job
@@ -8,7 +16,45 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
   register: k8s_job
 
+- name: Update AnsibleJob isFinished status if job succeeded
+  k8s_status:
+    api_version: tower.ansible.com/v1alpha1
+    kind: AnsibleJob
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    status:
+      isFinished: true
+  when:
+    - k8s_job['resources'][0]['status']['succeeded'] is defined
+    - k8s_job['resources'][0]['status']['succeeded'] == 1
+
+- name: End play early is AnsibleJob has already finished
+  meta: end_play
+  when:
+    - ansiblejob_info['resources'][0]['status']['isFinished'] is defined
+    - ansiblejob_info['resources'][0]['status']['isFinished']
+
 - block:
+    - name: Check number of attempts to execute the job have been made
+      set_fact:
+        _attempts: "{{ k8s_job['resources'][0]['status']['failed'] | default(0) }}"
+
+    - name: Set the maximum failed attempts allowed based on the backoffLimit
+      set_fact:
+        _failures_allowed: "{{ backoff_limit }} + 1"
+
+    - name: Update AnsibleJob status if backoff limit is exceeded
+      k8s_status:
+        api_version: tower.ansible.com/v1alpha1
+        kind: AnsibleJob
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        status:
+          isFinished: true
+          message: "This job instance reached its backoff limit. Inspect playbook output for more info."
+      when:
+        - _attempts >= _failures_allowed
+
     - name: Update AnsibleJob status with message
       k8s_status:
         api_version: tower.ansible.com/v1alpha1
@@ -19,7 +65,9 @@
           message: "This job instance is already running or has reached its end state."
     - name: End play early
       meta: end_play
-  when: k8s_job["resources"] is defined and (k8s_job["resources"]|length>0)
+  when:
+    - k8s_job['resources'] is defined
+    - (k8s_job["resources"]|length>0)
 
 - name: Read Secret Configuration
   k8s_info:

--- a/roles/job/templates/job_definition.yml.j2
+++ b/roles/job/templates/job_definition.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: "{{ ansible_operator_meta.name }}"
   namespace: "{{ ansible_operator_meta.namespace }}"
 spec:
-  ttlSecondsAfterFinished: 3600
+  ttlSecondsAfterFinished: {{ job_ttl | string }}
   template:
     spec:
       serviceAccountName: resource-operator-controller-manager-job
@@ -27,4 +27,4 @@ spec:
             - name: ANSIBLEJOB_NAMESPACE
               value: "{{ ansible_operator_meta.namespace }}"
       restartPolicy: Never
-  backoffLimit: 1
+  backoffLimit: {{ backoff_limit }}

--- a/roles/job/templates/job_definition.yml.j2
+++ b/roles/job/templates/job_definition.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: "{{ ansible_operator_meta.name }}"
   namespace: "{{ ansible_operator_meta.namespace }}"
 spec:
-  ttlSecondsAfterFinished: {{ job_ttl | string }}
+  ttlSecondsAfterFinished: {{ job_ttl }}
   template:
     spec:
       serviceAccountName: resource-operator-controller-manager-job


### PR DESCRIPTION
# Summary

  * k8s TTLAfterFinished feature cleans up finished jobs, and the
    absence of those jobs was making the AnsibleJob reconciliation loop
create a new job to replace it, thus re-running the automation.
  * Resolves https://github.com/ansible/awx-resource-operator/issues/49

## Details

For scenarios where the job fails, the "rescue" block re-runs the job in a new pod, and if that also fails, it will now set the `isFinished` status to `true`, which short-circuits the reconciliation loop on the next run, meaning that no other attempts are made.  Example output from the AnsibleJob resource's status:
```
        "conditions": [
            {
                "lastProbeTime": "2022-02-18T00:13:30Z",
                "lastTransitionTime": "2022-02-18T00:13:30Z",
                "message": "Job has reached the specified backoff limit",
                "reason": "BackoffLimitExceeded",
                "status": "True",
                "type": "Failed"
            }
        ],
        "failed": 2,
        "startTime": "2022-02-18T00:12:47Z"
    }
```

For success scenarios, the `isFinished` status on the AnsibleJob resource is set to `true` along with the other statuses that denote a successful job run. 

## Extra Information

A new parameter called `job_ttl` can now be configured on the AnsibleJob spec to set the time-to-live for a job that is in the finished state.  

For example:
```
---
apiVersion: tower.ansible.com/v1alpha1
kind: AnsibleJob
metadata:
  generateName: demo-job-1 # generate a unique suffix per 'kubectl create'
spec:
  tower_auth_secret: awxaccess
  job_template_name: Demo Job Template
  inventory: Demo Inventory # Inventory prompt on launch needs to be enabled
  runner_image: quay.io/chadams/awx-resource-runner
  job_ttl: 500
```
