### PR TITLE
Only inject annotations, use python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ bundle: kustomize ## Generate bundle manifests and metadata, then validate gener
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	cd config/manifests/bases && python inject-custom-config.py
+	cd config/manifests/bases && python3 inject-custom-annotations.py
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/config/manifests/bases/inject-custom-annotations.py
+++ b/config/manifests/bases/inject-custom-annotations.py
@@ -1,6 +1,5 @@
 '''
-After generating the bundle, inject custom configuration such as
-annotations, OLM parameters, etc.
+After generating the bundle, inject custom configuration for annotations.
 '''
 
 import yaml


### PR DESCRIPTION
This way we can be python3 everywhere (helps out downstream automation too).  