### PR TITLE
Add docs link for creating access token & update OLM params

### DIFF
--- a/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
+++ b/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
@@ -40,6 +40,8 @@ spec:
                 description: Runner image version used when running jobs
               tower_auth_secret:
                 type: string
+                description: |
+                  A k8s secret that contains an access token for AWX. To create an access token see these docs: https://docs.ansible.com/automation-controller/4.1.0/html/userguide/applications_auth.html#add-tokens.
               job_ttl:
                 description: Time to live for k8s job object after the playbook run has finished
                 type: integer

--- a/config/crd/bases/tower.ansible.com_jobtemplates.yaml
+++ b/config/crd/bases/tower.ansible.com_jobtemplates.yaml
@@ -39,6 +39,8 @@ spec:
                 type: boolean
               tower_auth_secret:
                 type: string
+                description: |
+                  A k8s secret that contains an access token for AWX. To create an access token see these docs: https://docs.ansible.com/automation-controller/4.1.0/html/userguide/applications_auth.html#add-tokens.
             required:
             - tower_auth_secret
             type: object

--- a/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
@@ -21,11 +21,72 @@ spec:
       displayName: AWX job
       kind: AnsibleJob
       name: ansiblejobs.tower.ansible.com
+      specDescriptors:
+      - displayName: Job Template Name
+        path: job_template_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: AWX Authentication Secret
+        path: tower_auth_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: AWX Inventory
+        path: inventory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Extra Variables
+        path: extra_vars
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Job TTL
+        path: job_ttl
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Ansible Runner Image
+        path: runner_image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Ansible Runner Version
+        path: runner_version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       version: v1alpha1
     - description: Define a new job template in awx
       displayName: AWX job template
       kind: JobTemplate
       name: jobtemplates.tower.ansible.com
+      specDescriptors:
+      - displayName: Job Template Name
+        path: job_template_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: AWX Authentication Secret
+        path: tower_auth_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Job Template Inventory
+        path: job_template_inventory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Job Template Playbook
+        path: job_template_playbook
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Job Template Project
+        path: job_template_project
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Job Template Ask Vars
+        path: job_template_ask_vars
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Job Template Ask Inventory
+        path: job_template_ask_inventory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1
   description: The Ansible Automation Platform Resource Operator manages launching
     Ansible Jobs and Workflows.
@@ -49,13 +110,14 @@ spec:
   keywords:
   - automation
   - ansible
+  - controller
   - tower
   - awx
   - resource
   - ci
   - cd
   links:
-  - name: Awx Operator
+  - name: AWX Operator
     url: https://github.com/ansible/awx-resource-operator
   maintainers:
   - email: ocm-dev@open-cluster-management.io

--- a/config/samples/tower_v1alpha1_ansiblejob.yaml
+++ b/config/samples/tower_v1alpha1_ansiblejob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: demo-job
   # generateName: demo-job- # generate a unique suffix per 'kubectl create'
 spec:
-  tower_auth_secret: toweraccess
+  tower_auth_secret: awxaccess
   job_template_name: Demo Job Template
   inventory: Demo Inventory # Inventory prompt on launch needs to be enabled
   extra_vars: # Extra variables prompt on launch needs to be enabled

--- a/config/samples/tower_v1alpha1_jobtemplate.yaml
+++ b/config/samples/tower_v1alpha1_jobtemplate.yaml
@@ -3,7 +3,7 @@ kind: JobTemplate
 metadata:
   name: jobtemplate-sample
 spec:
-  tower_auth_secret: toweraccess
+  tower_auth_secret: awxaccess
   job_template_name: ExampleJobTemplate
   job_template_project: Demo Project
   job_template_playbook: hello_world.yml


### PR DESCRIPTION
This adds a link to the docs for how to create an AWX access token.  I also updated a few other things while here:
* Some Tower references swapped out for AWX
* OLM parameters added 