### PR TITLE
fix var in workflow template

### DIFF
--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -111,7 +111,7 @@
 
 - name: Set Job or WFJT name
   set_fact:
-    _job_name: "{{ job_template_name |  default(workflow_job_template_name)}}"
+    _job_name: "{{ job_template_name |  default(workflow_template_name)}}"
 
 - name: Update AnsibleJob status with K8s job info
   k8s_status:


### PR DESCRIPTION
Var here was incorrectly defined, leading to error when trying to use workflow_template:
`
 The error was: 'workflow_job_template_name' is undefined\n\nThe error appears to be in '/opt/ansible/roles/job/tasks/main.yml': line 112, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set Job or WFJT name\n  ^ here\n"}[0m`
