### PR TITLE
Fix conditional for job vs workflow, check if env var is empty string

### DIFF
--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -10,11 +10,15 @@
 
 - name: Launch a job
   include_tasks: launch_job.yml
-  when: lookup('env','TOWER_JOB_TEMPLATE_NAME') is defined
+  when:
+    - lookup('env','TOWER_JOB_TEMPLATE_NAME') is defined
+    - lookup('env','TOWER_JOB_TEMPLATE_NAME') != ''
 
 - name: Launch Workflow
   include_tasks: launch_workflow.yml
-  when: lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') is defined
+  when:
+    - lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') is defined
+    - lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') != ''
 
 - name: Update AnsibleJob status with Tower job result
   k8s_status:


### PR DESCRIPTION
@rh-dluong FYI, the launch_job.yml and launch_workflow.yml playbooks were both being run every time.  Checking if the env var exists isn't enough, we have to make sure it isn't an empty string, otherwise it is true every time.  