### PR TITLE
molecule: fix lint configuration

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,10 @@
+---
+skip_list:
+  - '306'
+  - '602'
+  - '503'
+
+exclude_paths:
+  - deploy/
+  - .cache/
+

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,15 +6,13 @@ driver:
 lint: |
   set -e
   yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" .
+  ansible-lint
 platforms:
   - name: cluster
     groups:
       - k8s
 provisioner:
   name: ansible
-  lint: |
-    set -e
-    ansible-lint
   inventory:
     group_vars:
       all:
@@ -31,6 +29,3 @@ provisioner:
     K8S_AUTH_KUBECONFIG: ${KUBECONFIG:-"~/.kube/config"}
 verifier:
   name: ansible
-  lint: |
-    set -e
-    ansible-lint

--- a/molecule/kind/molecule.yml
+++ b/molecule/kind/molecule.yml
@@ -15,9 +15,6 @@ provisioner:
   playbooks:
     prepare: ../default/prepare.yml
     verify: ../default/verify.yml
-  lint: |
-    set -e
-    ansible-lint
   inventory:
     group_vars:
       all:
@@ -37,6 +34,3 @@ provisioner:
     KUBECONFIG: ${MOLECULE_EPHEMERAL_DIRECTORY}/kubeconfig
 verifier:
   name: ansible
-  lint: |
-    set -e
-    ansible-lint


### PR DESCRIPTION
Details in this similar PR: https://github.com/ansible/awx-operator/pull/1101

##### SUMMARY
The `lint` attribute in the provisioner and verifier configuration isn't supported anymore.
This also removes the molecule pin in the requirements.

https://molecule.readthedocs.io/en/latest/configuration.html#lint