### PR TITLE
Add ability to configure job_tags and skip_tags on AnsibleJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,16 @@ It is possible to configure other things like inventory, extra vars, and time to
 spec:
   tower_auth_secret: awx-access
   job_template_name: Demo Job Template
-  inventory: Demo Inventory                # Inventory prompt on launch needs to be enabled
+  inventory: Demo Inventory                    # Inventory prompt on launch needs to be enabled
   runner_image: quay.io/ansible/awx-resource-runner
   runner_version: latest
   job_ttl: 100
 
-  extra_vars:                              # Extra variables prompt on launch needs to be enabled
+  extra_vars:                                  # Extra variables prompt on launch needs to be enabled
      test_var: test
+
+  job_tags: "provision,install,configuration"  # Specify tags to run
+  skip_tags: "configuration,restart"           # Skip tasks with a given tag
 ```
 
 Note that prompt on launch needs to be enabled for inventories and extra vars if you are specifying those. In order to enable "PROMPT ON LAUNCH", within the AWX UI:

--- a/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
+++ b/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
@@ -53,6 +53,12 @@ spec:
               job_ttl:
                 description: Time to live for k8s job object after the playbook run has finished
                 type: integer
+              job_tags:
+                type: string
+                description: A comma-separated list of tags to specify which sets of ansible tasks in a job should be run
+              skip_tags:
+                type: string
+                description: A comma-separated list of tags to specify which sets of ansible tasks in a job should not be run
             required:
             - tower_auth_secret
             description: Spec defines the desired state of AnsibleJob

--- a/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
@@ -43,6 +43,16 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Job Tags
+        path: job_tags
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Skip Tags
+        path: skip_tags
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Ansible Runner Image
         path: runner_image
         x-descriptors:

--- a/config/samples/tower_v1alpha1_ansiblejob.yaml
+++ b/config/samples/tower_v1alpha1_ansiblejob.yaml
@@ -19,3 +19,5 @@ spec:
     - bbb
     - ccc
     version: 1.23.45
+  job_tags: "provision,install,configuration"
+  skip_tags: "configuration,restart"

--- a/roles/job_runner/tasks/launch_job.yml
+++ b/roles/job_runner/tasks/launch_job.yml
@@ -5,6 +5,8 @@
         job_template: "{{ lookup('env','TOWER_JOB_TEMPLATE_NAME') }}"
         extra_vars: "{{ ansible_job['resources'][0]['spec']['extra_vars'] | default(omit) }}"
         inventory: "{{ ansible_job['resources'][0]['spec']['inventory'] | default(omit) }}"
+        tags: "{{ ansible_job['resources'][0]['spec']['job_tags'] | default(omit) }}"
+        skip_tags: "{{ ansible_job['resources'][0]['spec']['skip_tags'] | default(omit) }}"
       register: job
   rescue:
     - name: Update status if job resulted in an error

--- a/roles/job_runner/tasks/launch_workflow.yml
+++ b/roles/job_runner/tasks/launch_workflow.yml
@@ -5,6 +5,8 @@
         name: "{{ lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') }}"
         extra_vars: "{{ ansible_job['resources'][0]['spec']['extra_vars'] | default(omit) }}"
         inventory: "{{ ansible_job['resources'][0]['spec']['inventory'] | default(omit) }}"
+        tags: "{{ ansible_job['resources'][0]['spec']['job_tags'] | default(omit) }}"
+        skip_tags: "{{ ansible_job['resources'][0]['spec']['skip_tags'] | default(omit) }}"
       register: job
   rescue:
     - name: Update status if job resulted in an error


### PR DESCRIPTION
Add support for configuration of ansible tags.  

* job_tags - if specified, will only run the tasks with those tags
* skip_tags - if specified, will explicitly skip tasks with those tags

> Note: you need to set Prompt on Launch to true for both of these settings on the job template in question.  You also need to add the configurable tags to the job_template.  

![image](https://user-images.githubusercontent.com/11698892/199059438-8f8bdb38-b8e2-4579-b1fc-0327eaf5df7a.png)



-------------------------


At the command line, with just ansible, this looks like:

```
$ ansible-playbook -i inventory testing-tags.yml --tag hello
```

In AWX/Controller, job_tags and skip_tags are settings on a Job Template (and can be prompt on launch).
I tested this with the following  playbook:
* https://github.com/rooftopcellist/Test-Playbooks/blob/master/testing-tags.yml
