### PR TITLE
Reference the secret name rather than env var

### DIFF
--- a/roles/job/templates/job_definition.yml.j2
+++ b/roles/job/templates/job_definition.yml.j2
@@ -17,12 +17,12 @@ spec:
             - name: TOWER_OAUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: "{{ tower_config_secret['resources'][0]['metadata']['name'] }}"
+                  name: "{{ tower_auth_secret }}"
                   key: token
             - name: TOWER_HOST
               valueFrom:
                 secretKeyRef:
-                  name: "{{ tower_config_secret['resources'][0]['metadata']['name'] }}"
+                  name: "{{ tower_auth_secret }}"
                   key: host
 {% if job_template_name is defined and job_template_name != "" %}
             - name: TOWER_JOB_TEMPLATE_NAME

--- a/roles/job/templates/job_definition.yml.j2
+++ b/roles/job/templates/job_definition.yml.j2
@@ -15,9 +15,15 @@ spec:
           imagePullPolicy: Always
           env:
             - name: TOWER_OAUTH_TOKEN
-              value: "{{ tower_config_secret['resources'][0]['data']['token'] | b64decode }}"
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ tower_config_secret['resources'][0]['metadata']['name'] }}"
+                  key: token
             - name: TOWER_HOST
-              value: "{{ tower_config_secret['resources'][0]['data']['host'] | b64decode }}"
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ tower_config_secret['resources'][0]['metadata']['name'] }}"
+                  key: host
 {% if job_template_name is defined and job_template_name != "" %}
             - name: TOWER_JOB_TEMPLATE_NAME
               value: "{{ job_template_name }}"


### PR DESCRIPTION
We should reference the secret within the job rather than populate it as an environment variable to be viewable when asking for the yaml.

```
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2022-10-31T17:20:16Z"
  generateName: kendrick-lamar-
  labels:
    controller-uid: 900f8b3c-b4b7-47f9-9273-457edeb4fe21
    job-name: kendrick-lamar
  name: kendrick-lamar-pzpdf
  namespace: ansible-automation-platform
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: kendrick-lamar
    uid: 900f8b3c-b4b7-47f9-9273-457edeb4fe21
  resourceVersion: "15087"
  uid: e55deee3-9e49-4214-80ad-b78266968e1a
spec:
  containers:
  - env:
    - name: TOWER_OAUTH_TOKEN
      valueFrom:
        secretKeyRef:
          key: token
          name: controller-access-secret
    - name: TOWER_HOST
      valueFrom:
        secretKeyRef:
          key: host
          name: controller-access-secret
```

closes #91 

Signed-off-by: Ryan Cook <rcook@redhat.com>