### PR TITLE
minor fix to README title and AnsibleJob sample CR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-quay.io/ansible/awx-resource-operator# AWX Resource Operator
+# AWX Resource Operator
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build Status](https://github.com/ansible/awx-resource-operator/workflows/CI/badge.svg?event=push)](https://github.com/ansible/awx-resource-operator/actions)

--- a/config/samples/tower_v1alpha1_ansiblejob.yaml
+++ b/config/samples/tower_v1alpha1_ansiblejob.yaml
@@ -19,5 +19,5 @@ spec:
     - bbb
     - ccc
     version: 1.23.45
-  job_tags: "provision,install,configuration"
+  job_tags: "provision,install"
   skip_tags: "configuration,restart"


### PR DESCRIPTION
In the AnsibleJob sample CR, the value `configuration` exists in both `job_tags` and `skip_tags` which is confusing for users.

Fix the README title on what looks like a copy and paste mistake.

Signed-off-by: Mike Ng <ming@redhat.com>