### PR TITLE
Raise resource limits on operator to avoid being OOMKilled

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,8 +72,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: 500m
-            memory: 768Mi
+            cpu: 1000m
+            memory: 2Gi
           requests:
             cpu: 10m
             memory: 256Mi


### PR DESCRIPTION
We received some feedback that the default limits were too low, specifically for memory.  

FYI, with OLM installs, these values can be tweaked on the subscription:
* https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/subscription-config.md#resources