### PR TITLE
Fix CSV rendering issue caused by syntax error

### DIFF
--- a/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
@@ -127,7 +127,7 @@ spec:
     - description: Define an Instance Group
       displayName: AWX Instance Group
       kind: AnsibleInstanceGroup
-      name: ansibleinstancegroupss.tower.ansible.com
+      name: ansibleinstancegroups.tower.ansible.com
       specDescriptors:
       - displayName: Instance Group Name
         path: name
@@ -328,6 +328,7 @@ spec:
         path: survey_spec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      version: v1alpha1
     - description: Define a new project in awx
       displayName: AWX Project
       kind: AnsibleProject


### PR DESCRIPTION
The specDescriptors section of AnsibleInstanceGroups and WorkflowTemplates was getting discarded from the rendered CSV.  This fixes the syntax issues that were causing that.  

Now running `make bundle` renders correctly.  