### PR TITLE
Refactor deprecated ansiblejob workflow to be a distinct code path

### DIFF
--- a/.github/workflows/kind-awx.yaml
+++ b/.github/workflows/kind-awx.yaml
@@ -137,7 +137,7 @@ jobs:
         run: |
           sleep 10
           kubectl wait awx -n awx awx-demo --for condition=Successful=true --timeout=720s
-          kubectl wait deployment -n awx awx-demo-task --for condition=Available=True --timeout=500s
+          kubectl wait deployment -n awx awx-demo-task --for condition=Available=True --timeout=600s
           kubectl wait deployment -n awx awx-demo-web --for condition=Available=True --timeout=500s
           kubectl apply -f test-e2e/token.yaml
           kubectl wait job -n awx create-token --for condition=Complete --timeout=60s
@@ -155,13 +155,13 @@ jobs:
       - name: launch a job
         run: |
           kubectl apply -f test-e2e/tests/job.yaml
-          kubectl wait ansiblejob -n awx demo-job --for condition=Successful=True --timeout=60s
+          kubectl wait ansiblejob -n awx demo-job --for condition=Successful=True --timeout=80s
           kubectl apply -f config/samples/tower_v1alpha1_ansiblejob-broken.yaml -n awx
-          kubectl wait ansiblejob -n awx broke-job --for condition=Successful=True --timeout=60s
+          kubectl wait ansiblejob -n awx broke-job --for condition=Successful=True --timeout=80s
           kubectl apply -f test-e2e/tests/job-deprecated.yaml
-          kubectl wait ansiblejob -n awx demo-job-deprecated --for condition=Successful=True --timeout=60s
+          kubectl wait ansiblejob -n awx demo-job-deprecated --for condition=Successful=True --timeout=80s
           kubectl apply -f config/samples/tower_v1alpha1_ansiblejob-broken-dep.yaml -n awx
-          kubectl wait ansiblejob -n awx broke-job-deprecated --for condition=Successful=True --timeout=60s
+          kubectl wait ansiblejob -n awx broke-job-deprecated --for condition=Successful=True --timeout=80s
 
       - name: launch a template
         run: |

--- a/roles/job_runner/tasks/launch_deprecated_job.yml
+++ b/roles/job_runner/tasks/launch_deprecated_job.yml
@@ -1,9 +1,14 @@
 ---
+- name: Deprecation Warning
+  debug:
+    msg: "Using an AnsibleJob to run workflows is deprecated. Please use an AnsibleWorkflow instead."
+    verbosity: 0
+
 - name: Launch a job, if error update AnsibleJob status then end play
   block:
     - name: Launch job
-      awx.awx.job_launch:
-        name: "{{ lookup('env','TOWER_JOB_TEMPLATE_NAME') }}"
+      awx.awx.workflow_launch:
+        name: "{{ lookup('env','TOWER_DEPRECATED_WORKFLOW_TEMPLATE_NAME') }}"
         extra_vars: "{{ ansible_job['resources'][0]['spec']['extra_vars'] | default(omit) }}"
         inventory: "{{ ansible_job['resources'][0]['spec']['inventory'] | default(omit) }}"
         tags: "{{ ansible_job['resources'][0]['spec']['job_tags'] | default(omit) }}"
@@ -42,17 +47,17 @@
     name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
     namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
     status:
-      ansibleJobResult:
         changed: "{{ job.changed }}"
         failed: "{{ job.failed }}"
         status: "{{ job.status }}"
-        url: "{{ lookup('env', 'TOWER_HOST') + '/#/jobs/playbook/' + (job.id|string) }}"
+        url: "{{ lookup('env', 'TOWER_HOST') + '/#/jobs/workflow/' + (job.id|string) }}"
 
 - name: Wait for the tower job, if error update AnsibleJob status then end play
   block:
     - name: Register Job result when complete
       awx.awx.job_wait:
         job_id: "{{ job.id }}"
+        job_type: workflow_jobs
       register: job_result
   rescue:
     - name: Update status if job results in an error

--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -23,46 +23,58 @@
     - lookup('env','ANSIBLEINSTANCEGROUP_NAME') is defined
     - lookup('env','ANSIBLEINSTANCEGROUP_NAME') != ''
 
+- name: Read in Environment Variables
+  set_fact:
+    ansible_job_name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
+    ansible_job_namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+    ansible_workflow_name: "{{ lookup('env', 'ANSIBLEWORKFLOW_NAME') }}"
+    ansible_workflow_namespace: "{{ lookup('env', 'ANSIBLEWORKFLOW_NAMESPACE') }}"
+    tower_job_template_name: "{{ lookup('env', 'TOWER_JOB_TEMPLATE_NAME') }}"
+    tower_workflow_template_name: "{{ lookup('env', 'TOWER_WORKFLOW_TEMPLATE_NAME') }}"
+    tower_deprecated_workflow_template_name: "{{ lookup('env', 'TOWER_DEPRECATED_WORKFLOW_TEMPLATE_NAME') }}"
+
+- name: Set Conditions as Facts
+  set_fact:
+    is_tower_job_template_defined: "{{ tower_job_template_name is defined and tower_job_template_name != '' }}"
+    is_tower_workflow_template_defined: "{{ tower_workflow_template_name is defined and tower_workflow_template_name != '' }}"
+    is_tower_deprecated_workflow_template_defined: "{{ tower_deprecated_workflow_template_name is defined and tower_deprecated_workflow_template_name != '' }}"
+
 - name: Read AnsibleJob Specs
   kubernetes.core.k8s_info:
     kind: AnsibleJob
     api_version: tower.ansible.com/v1alpha1
-    name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
-    namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+    name: "{{ ansible_job_name }}"
+    namespace: "{{ ansible_job_namespace }}"
   register: ansible_job
-  when: >-
-    (lookup('env', 'TOWER_JOB_TEMPLATE_NAME') is defined and lookup('env', 'TOWER_JOB_TEMPLATE_NAME') != '') or
-    (lookup('env', 'TOWER_DEPRECATED_WORKFLOW_TEMPLATE_NAME') is defined and lookup('env', 'TOWER_DEPRECATED_WORKFLOW_TEMPLATE_NAME') != '')
+  when: is_tower_job_template_defined or is_tower_deprecated_workflow_template_defined
 
 - name: Read AnsibleWorkflow Specs
   kubernetes.core.k8s_info:
     kind: AnsibleWorkflow
     api_version: tower.ansible.com/v1alpha1
-    name: "{{ lookup('env', 'ANSIBLEWORKFLOW_NAME') }}"
-    namespace: "{{ lookup('env', 'ANSIBLEWORKFLOW_NAMESPACE') }}"
+    name: "{{ ansible_workflow_name }}"
+    namespace: "{{ ansible_workflow_namespace }}"
   register: ansible_workflow
-  when:
-    - lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') is defined
-    - lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') != ''
+  when: is_tower_workflow_template_defined
 
 - name: Launch a job
   include_tasks: launch_job.yml
-  when: >-
-    (lookup('env', 'TOWER_JOB_TEMPLATE_NAME') is defined and lookup('env', 'TOWER_JOB_TEMPLATE_NAME') != '') or
-    (lookup('env', 'TOWER_DEPRECATED_WORKFLOW_TEMPLATE_NAME') is defined and lookup('env', 'TOWER_DEPRECATED_WORKFLOW_TEMPLATE_NAME') != '')
+  when: is_tower_job_template_defined
+
+- name: Launch (Deprecated) AnsibleJob Workflow
+  include_tasks: launch_deprecated_job.yml
+  when: is_tower_deprecated_workflow_template_defined
 
 - name: Launch Workflow
   include_tasks: launch_workflow.yml
-  when:
-    - lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') is defined
-    - lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') != ''
+  when: is_tower_workflow_template_defined
 
 - name: Update AnsibleJob status with Tower job result
   operator_sdk.util.k8s_status:
     api_version: tower.ansible.com/v1alpha1
     kind: AnsibleJob
-    name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
-    namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+    name: "{{ ansible_job_name }}"
+    namespace: "{{ ansible_job_namespace }}"
     status:
       ansibleJobResult:
         elapsed: "{{ job_result.elapsed }}"
@@ -70,21 +82,19 @@
         started: "{{ job_result.started }}"
         status: "{{ job_result.status }}"
   when: >-
-    (lookup('env', 'TOWER_JOB_TEMPLATE_NAME') is defined and lookup('env', 'TOWER_JOB_TEMPLATE_NAME') != '') or
-    (lookup('env', 'TOWER_DEPRECATED_WORKFLOW_TEMPLATE_NAME') is defined and lookup('env', 'TOWER_DEPRECATED_WORKFLOW_TEMPLATE_NAME') != '')
+    is_tower_job_template_defined or
+    is_tower_deprecated_workflow_template_defined
 
 - name: Update AnsibleWorkflow status with Tower workflow result
   operator_sdk.util.k8s_status:
     api_version: tower.ansible.com/v1alpha1
     kind: AnsibleWorkflow
-    name: "{{ lookup('env', 'ANSIBLEWORKFLOW_NAME') }}"
-    namespace: "{{ lookup('env', 'ANSIBLEWORKFLOW_NAMESPACE') }}"
+    name: "{{ ansible_workflow_name }}"
+    namespace: "{{ ansible_workflow_namespace }}"
     status:
       ansibleWorkflowResult:
         elapsed: "{{ job_result.elapsed }}"
         finished: "{{ job_result.finished }}"
         started: "{{ job_result.started }}"
         status: "{{ job_result.status }}"
-  when:
-    - lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') is defined
-    - lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') != ''
+  when: is_tower_workflow_template_defined


### PR DESCRIPTION
 - This fixes a critical bug in the conditionals for evaluating when to use the launch_workflow.yml tasks.
 - Prior to this change, AnsibleJob objects with a job_workflow_template name specified would run to completion without error, but the task to launch the workflow was skipped.
 - The job_runner role was restructured to be more readable.
 - Adds a deprecation warning when the old ansiblejob workflow CR option is used.

Follow-up for https://github.com/ansible/awx-resource-operator/pull/140