### PR TITLE
Check for both auth secret names when setting statuses 

### DIFF
--- a/roles/credential/tasks/main.yml
+++ b/roles/credential/tasks/main.yml
@@ -94,6 +94,6 @@
         namespacedName: "{{ ansible_operator_meta.namespace+'/'+ansible_operator_meta.name }}"
         env:
           inventory: "{{ inventory | default(omit) }}"
-          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+connection_secret }}"
+          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+(connection_secret | default(tower_auth_secret, true)) }}"
           credentialName: "{{ _credential_name }}"
           verifySSL: false

--- a/roles/instancegroup/tasks/main.yml
+++ b/roles/instancegroup/tasks/main.yml
@@ -108,6 +108,6 @@
         namespacedName: "{{ ansible_operator_meta.namespace+'/'+ansible_operator_meta.name }}"
         env:
           inventory: "{{ inventory | default(omit) }}"
-          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+connection_secret }}"
+          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+(connection_secret | default(tower_auth_secret, true)) }}"
           instance_groupName: "{{ _instance_group_name }}"
           verifySSL: false

--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -120,6 +120,6 @@
         namespacedName: "{{ ansible_operator_meta.namespace+'/'+ansible_operator_meta.name }}"
         env:
           inventory: "{{ inventory | default(omit) }}"
-          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+tower_auth_secret }}"
+          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+(connection_secret | default(tower_auth_secret, true)) }}"
           templateName: "{{ _job_name }}"
           verifySSL: false

--- a/roles/project/tasks/main.yml
+++ b/roles/project/tasks/main.yml
@@ -94,6 +94,6 @@
         namespacedName: "{{ ansible_operator_meta.namespace+'/'+ansible_operator_meta.name }}"
         env:
           inventory: "{{ inventory | default(omit) }}"
-          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+connection_secret }}"
+          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+(connection_secret | default(tower_auth_secret, true)) }}"
           projectName: "{{ _project_name }}"
           verifySSL: false

--- a/roles/schedule/tasks/main.yml
+++ b/roles/schedule/tasks/main.yml
@@ -94,6 +94,6 @@
         namespacedName: "{{ ansible_operator_meta.namespace+'/'+ansible_operator_meta.name }}"
         env:
           inventory: "{{ inventory | default(omit) }}"
-          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+connection_secret }}"
+          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+(connection_secret | default(tower_auth_secret, true)) }}"
           scheduleName: "{{ _schedule_name }}"
           verifySSL: false

--- a/roles/workflow/tasks/main.yml
+++ b/roles/workflow/tasks/main.yml
@@ -120,6 +120,6 @@
         namespacedName: "{{ ansible_operator_meta.namespace+'/'+ansible_operator_meta.name }}"
         env:
           inventory: "{{ inventory | default(omit) }}"
-          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+connection_secret }}"
+          secretNamespacedName: "{{ ansible_operator_meta.namespace+'/'+(connection_secret | default(tower_auth_secret, true)) }}"
           templateName: "{{ _job_name }}"
           verifySSL: false


### PR DESCRIPTION
Fixes https://github.com/ansible/awx-resource-operator/issues/141

Replaces https://github.com/ansible/awx-resource-operator/pull/142