### PR TITLE
Improve the error handling when jobs fail

### DIFF
--- a/roles/job_runner/tasks/launch_deprecated_job.yml
+++ b/roles/job_runner/tasks/launch_deprecated_job.yml
@@ -24,7 +24,7 @@
         status:
           ansibleJobResult:
             status: "error"
-          error_message: "{{ job.msg }}"
+          error_message: "{{ job.msg | default('Job failed to launch. Verify that the credentials in your connection_secret are correct. If they are, check the job standard output for more details.') }}"
     - name: End playbook run
       meta: end_play
 
@@ -69,6 +69,6 @@
         status:
           ansibleJobResult:
             status: "error"
-          error_message: "{{ job.msg }}"
+          error_message: "{{ job_result.msg | default('Job failed, check the job for more information: lookup('env', 'TOWER_HOST') + '/#/jobs/workflow/' + (job.id|string)') }}"
     - name: End playbook run
       meta: end_play

--- a/roles/job_runner/tasks/launch_job.yml
+++ b/roles/job_runner/tasks/launch_job.yml
@@ -19,7 +19,7 @@
         status:
           ansibleJobResult:
             status: "error"
-          error_message: "{{ job.msg }}"
+          error_message: "{{ job.msg | default('Job failed to launch. Verify that the credentials in your connection_secret are correct. If they are, check the job standard output for more details.') }}"
     - name: End playbook run
       meta: end_play
 
@@ -64,6 +64,6 @@
         status:
           ansibleJobResult:
             status: "error"
-          error_message: "{{ job.msg }}"
+          error_message: "{{ job_result.msg | default('Job failed, check the job for more information: lookup('env', 'TOWER_HOST') + '/#/jobs/playbook/' + (job.id|string)') }}"
     - name: End playbook run
       meta: end_play

--- a/roles/job_runner/tasks/launch_workflow.yml
+++ b/roles/job_runner/tasks/launch_workflow.yml
@@ -18,7 +18,7 @@
         status:
           AnsibleWorkflowResult:
             status: "error"
-          error_message: "{{ job.msg }}"
+          error_message: "{{ job.msg | default('Job failed to launch. Verify that the credentials in your connection_secret are correct. If they are, check the job standard output for more details.') }}"
     - name: End playbook run
       meta: end_play
 
@@ -64,6 +64,7 @@
         status:
           ansibleWorkflowesult:
             status: "error"
-          error_message: "{{ job_result.msg }}"
+          error_message: "{{ job_result.msg | default('Job failed, check the job for more information: lookup('env', 'TOWER_HOST') + '/#/jobs/workflow/' + (job.id|string)') }}"
+
     - name: End playbook run
       meta: end_play


### PR DESCRIPTION
There is currently a bug where `job.msg` is not defined.  This is because at that point in the playbook, it should have been referenced as `job_result.msg`.  

While fixing this, I added some better error messages in general.  