### PR TITLE
csv: Fix AWX Inventory name

### DIFF
--- a/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
@@ -414,7 +414,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1
     - description: Define a new Inventory in awx
-      displayName: AWX Schedule
+      displayName: AWX Inventory
       kind: AnsibleInventory
       name: ansibleinventories.tower.ansible.com
       specDescriptors:


### PR DESCRIPTION
This was copied from AWX Schedule in 6eaf98e but not renamed.