### PR TITLE
Set max current reconciles flag in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY watches.yaml ${HOME}/watches.yaml
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
 
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/ansible-operator", "run", "--watches-file=./watches.yaml", "--reconcile-period=0s"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/ansible-operator", "run", "--watches-file=./watches.yaml", "--reconcile-period=0s", "--max-concurrent-reconciles", "2"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: awx-resource-manager
       labels:
         control-plane: controller-manager
     spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,11 +37,14 @@ spec:
       - args:
         - --leader-elect
         - --leader-election-id=awx-resource-operator
-        - --max-concurrent-reconciles=15
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: awx-resource-manager
         env:
+        - name: MAX_CONCURRENT_RECONCILES_ANSIBLEJOB_TOWER_ANSIBLE_COM
+          value: "5"
+        - name: MAX_CONCURRENT_RECONCILES_ANSIBLEWORKFLOW_TOWER_ANSIBLE_COM
+          value: "5"
         - name: ANSIBLE_GATHERING
           value: explicit
         - name: ANSIBLE_DEBUG_LOGS


### PR DESCRIPTION
Set max current reconciles flag in Dockerfile because setting it in config/manager/manager.yaml args section didn't work. I set the default low, to 2, but set ansiblejob and ansibleworkflow higher at 3.  This throttling should help us not overwhelm the operator container.

- Set max concurrent ansiblejob to 3
- Set max concurrent ansibleworkflow to 3

Follow up for https://github.com/ansible/awx-resource-operator/pull/150

Users can increase these values by setting new env vars on the Subscription or Deployment for the operator.  