### PR TITLE
feat: bump kustomize version to 5.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ ifeq (,$(shell which kustomize 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(KUSTOMIZE)) ;\
-	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.2/kustomize_v4.5.2_$(OS)_$(ARCH).tar.gz | \
+	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.3.0/kustomize_v5.3.0_$(OS)_$(ARCH).tar.gz | \
 	tar xzf - -C bin/ ;\
 	}
 else

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,11 +18,11 @@ namePrefix: resource-operator-
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-patchesStrategicMerge:
-- manager_auth_proxy_patch.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../crd
 - ../rbac
 - ../manager
+patches:
+- path: manager_auth_proxy_patch.yaml

--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -7,10 +7,6 @@ namePrefix: osdk-
 #commonLabels:
 #  someName: someValue
 
-patchesStrategicMerge:
-- manager_image.yaml
-- debug_logs_patch.yaml
-- ../default/manager_auth_proxy_patch.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -23,3 +19,6 @@ images:
   newName: testing-operator
 patches:
 - path: pull_policy/Never.yaml
+- path: manager_image.yaml
+- path: debug_logs_patch.yaml
+- path: ../default/manager_auth_proxy_patch.yaml


### PR DESCRIPTION
Closes #157 

As suggested in the deprecated message, `kustomize edit fix` was applied to `config/manager` (no changes), `config/default`, and `config/testing`.

Tested as follows:

```bash
# Ensure no existing kustomize binary in path
$ which kustomize
/usr/bin/which: no kustomize in (...)

# Ensure Operator can be deployed without any warning messages
$ NAMESPACE=awx IMG=quay.io/ansible/awx-resource-operator:latest make deploy
cd config/manager && /.../awx-resource-operator/bin/kustomize edit set image controller=quay.io/ansible/awx-resource-operator:latest
# Add a way to inject the runner image
cd config/default && /.../awx-resource-operator/bin/kustomize edit set namespace awx
/.../awx-resource-operator/bin/kustomize build config/default | kubectl apply -f -
namespace/awx created
customresourcedefinition.apiextensions.k8s.io/ansiblecredentials.tower.ansible.com created
customresourcedefinition.apiextensions.k8s.io/ansibleinstancegroups.tower.ansible.com created
customresourcedefinition.apiextensions.k8s.io/ansibleinventories.tower.ansible.com created
customresourcedefinition.apiextensions.k8s.io/ansiblejobs.tower.ansible.com created
customresourcedefinition.apiextensions.k8s.io/ansibleprojects.tower.ansible.com created
customresourcedefinition.apiextensions.k8s.io/ansibleschedules.tower.ansible.com created
customresourcedefinition.apiextensions.k8s.io/ansibleworkflows.tower.ansible.com created
customresourcedefinition.apiextensions.k8s.io/jobtemplates.tower.ansible.com created
customresourcedefinition.apiextensions.k8s.io/workflowtemplates.tower.ansible.com created
serviceaccount/resource-operator-controller-manager created
role.rbac.authorization.k8s.io/resource-operator-awx-resource-manager-role created
role.rbac.authorization.k8s.io/resource-operator-leader-election-role created
clusterrole.rbac.authorization.k8s.io/resource-operator-metrics-reader created
clusterrole.rbac.authorization.k8s.io/resource-operator-proxy-role created
rolebinding.rbac.authorization.k8s.io/resource-operator-awx-resource-manager-rolebinding created
rolebinding.rbac.authorization.k8s.io/resource-operator-leader-election-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/resource-operator-proxy-rolebinding created
configmap/resource-operator-awx-resource-manager-config created
service/resource-operator-controller-manager-metrics-service created
deployment.apps/resource-operator-controller-manager created

# Ensure newer kustomize was downloaded
$ ./bin/kustomize version
v5.3.0
```