### PR TITLE
Make Deprecated Fields Hidden in CSV

### DIFF
--- a/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
@@ -33,8 +33,7 @@ spec:
       - displayName: AWX Authentication Secret (DEPRECATED)
         path: tower_auth_secret
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:io.kubernetes:Secret
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Authentication Secret
         path: connection_secret
         x-descriptors:
@@ -250,8 +249,7 @@ spec:
       - displayName: AWX Authentication Secret(DEPRECATED)
         path: tower_auth_secret
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:io.kubernetes:Secret
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Authentication Secret
         path: connection_secret
         x-descriptors:


### PR DESCRIPTION
After https://github.com/ansible/awx-resource-operator/pull/156#discussion_r1449476052

Changed the descriptors of the automation controller authentication secret field in csv from text to hidden.

Before:
```yaml
- displayName: AWX Authentication Secret (DEPRECATED)
        path: tower_auth_secret
        x-descriptors:
        - urn:alm:descriptor:com.tectonic.ui:text
        - urn:alm:descriptor:io.kubernetes:Secret
```

After
```yaml
- displayName: AWX Authentication Secret (DEPRECATED)
        path: tower_auth_secret
        x-descriptors:
        - urn:alm:descriptor:com.tectonic.ui:hidden
```