### PR TITLE
Use correct ansible_workflow variable for workflows to fix extra_vars param usage

### DIFF
--- a/roles/job_runner/tasks/launch_workflow.yml
+++ b/roles/job_runner/tasks/launch_workflow.yml
@@ -3,10 +3,10 @@
     - name: Launch workflow
       awx.awx.workflow_launch:
         name: "{{ lookup('env','TOWER_WORKFLOW_TEMPLATE_NAME') }}"
-        extra_vars: "{{ ansible_job['resources'][0]['spec']['extra_vars'] | default(omit) }}"
-        inventory: "{{ ansible_job['resources'][0]['spec']['inventory'] | default(omit) }}"
-        tags: "{{ ansible_job['resources'][0]['spec']['job_tags'] | default(omit) }}"
-        skip_tags: "{{ ansible_job['resources'][0]['spec']['skip_tags'] | default(omit) }}"
+        extra_vars: "{{ ansible_workflow['resources'][0]['spec']['extra_vars'] | default(omit) }}"
+        inventory: "{{ ansible_workflow['resources'][0]['spec']['inventory'] | default(omit) }}"
+        tags: "{{ ansible_workflow['resources'][0]['spec']['job_tags'] | default(omit) }}"
+        skip_tags: "{{ ansible_workflow['resources'][0]['spec']['skip_tags'] | default(omit) }}"
       register: job
   rescue:
     - name: Update status if job resulted in an error


### PR DESCRIPTION
## Summary

Use correct ansible_workflow variable for workflows to fix extra_vars param usage.

## Problem being fixed

When trying to do post deployment config of a VM in ocp virt with an AAP workflow. The VM is deployed with Gitops and I was thinking of triggering the ansible workflow by applying an ansible CR. This is what my CR looks like,  

```
apiVersion: tower.ansible.com/v1alpha1
kind: AnsibleWorkflow
metadata:
  name: rhel9-gitops1-1
  namespace: aap
spec:
  connection_secret: controller-access-admin
  workflow_template_name: "gitops-post-config"
  inventory: virtcluster # Inventory prompt on launch needs to be enabled
  extra_vars: # Extra variables prompt on launch needs to be enabled
    vm_name: rhel9-gitops1-1
```

**The problem: extra_vars are not picked up in AAP workflow.  When using a JT it works, but not with WJT.** 