### PR TITLE
Add optional artifacts to the status

### DIFF
--- a/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
+++ b/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
@@ -38,6 +38,9 @@ spec:
                 type: string
               job_template_name:
                 type: string
+              artifacts:
+                type: boolean
+                description: if set to true, the job artifacts are included in the job result
               workflow_template_name:
                 type: string
               request_timeout:
@@ -69,7 +72,7 @@ spec:
                 description: |
                   A k8s secret that contains an access token for AWX. To create an access token see these docs: https://docs.ansible.com/automation-controller/4.1.0/html/userguide/applications_auth.html#add-tokens.
                 type: string
-            required:
+            required: []
             description: Spec defines the desired state of AnsibleJob
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/roles/job_runner/tasks/launch_job.yml
+++ b/roles/job_runner/tasks/launch_job.yml
@@ -46,7 +46,7 @@
         changed: "{{ job.changed }}"
         failed: "{{ job.failed }}"
         status: "{{ job.status }}"
-        url: "{{ lookup('env', 'TOWER_HOST') + '/#/jobs/playbook/' + (job.id|string) }}"
+        url: "{{ lookup('env', 'TOWER_HOST') | regex_replace('\\/$', '') + '/#/jobs/playbook/' + (job.id|string) }}"
 
 - name: Wait for the tower job, if error update AnsibleJob status then end play
   block:
@@ -55,6 +55,27 @@
         job_id: "{{ job.id }}"
         request_timeout: "{{ request_timeout }}"
       register: job_result
+
+    - name: Get job result data
+      awx.awx.job_list:
+        query: {"id": "{{ job.id }}"}
+      register: job_data
+      when:
+        - ansible_job['resources'][0]['spec']['artifacts'] | default(false)
+
+    - name: Register artifacts
+      operator_sdk.util.k8s_status:
+        api_version: tower.ansible.com/v1alpha1
+        kind: AnsibleJob
+        name: "{{ ansible_job_name }}"
+        namespace: "{{ ansible_job_namespace }}"
+        status:
+          ansibleJobResult:
+            artifacts: "{{ job_data.results[0].artifacts | default({}) }}"
+      when:
+        - ansible_job['resources'][0]['spec']['artifacts'] | default(false)
+        - job_data.results[0] is defined
+
   rescue:
     - name: Update status if job results in an error
       operator_sdk.util.k8s_status:
@@ -65,6 +86,6 @@
         status:
           ansibleJobResult:
             status: "error"
-          error_message: "{{ job_result.msg | default('Job failed, check the job for more information: lookup('env', 'TOWER_HOST') + '/#/jobs/playbook/' + (job.id|string)') }}"
+          error_message: "{{ job_result.msg | default(\"Job failed, check the job for more information: lookup('env', 'TOWER_HOST') + '/#/jobs/playbook/' + (job.id|string)\") }}"
     - name: End playbook run
       meta: end_play


### PR DESCRIPTION
Adds the ability to retrieve job artifacts dictionary within the `AnsibleJob` results. By default, artifacts are not retrieved, unless you opt-in the CRD:

```yaml
---
apiVersion: tower.ansible.com/v1alpha1
kind: AnsibleJob
metadata:
  name: demo-artifacts
spec:
  connection_secret: awx-access
  job_template_name: Demo Artifacts
  artifacts: true
```

Related to #168 