### PR TITLE
allow launch job again after TTL expires

### DIFF
--- a/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
+++ b/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
@@ -38,6 +38,9 @@ spec:
                 type: string
               job_template_name:
                 type: string
+              launch_once:
+                type: boolean
+                description: if not explicitly set to false, the job template is only launched once
               workflow_template_name:
                 type: string
               request_timeout:
@@ -69,7 +72,7 @@ spec:
                 description: |
                   A k8s secret that contains an access token for AWX. To create an access token see these docs: https://docs.ansible.com/automation-controller/4.1.0/html/userguide/applications_auth.html#add-tokens.
                 type: string
-            required:
+            required: []
             description: Spec defines the desired state of AnsibleJob
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/roles/job/defaults/main.yml
+++ b/roles/job/defaults/main.yml
@@ -3,3 +3,4 @@
 
 job_ttl: 3600
 backoff_limit: 1
+launch_once: true

--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -13,17 +13,12 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
   register: k8s_job
 
-- name: Update AnsibleJob isFinished status if job succeeded
-  operator_sdk.util.k8s_status:
-    api_version: tower.ansible.com/v1alpha1
-    kind: AnsibleJob
-    name: "{{ ansible_operator_meta.name }}"
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    status:
-      isFinished: true
+- name: End play early is Job succeeded and is set to run once
+  meta: end_play
   when:
     - k8s_job['resources'][0]['status']['succeeded'] is defined
     - k8s_job['resources'][0]['status']['succeeded'] == 1
+    - launch_once
 
 - name: Read AnsibleJob info
   kubernetes.core.k8s_info:
@@ -33,11 +28,13 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
   register: ansiblejob_info
 
-- name: End play early is AnsibleJob has already finished
+- name: End play early is Job TTL expired and is set to run once
   meta: end_play
   when:
-    - ansiblejob_info['resources'][0]['status']['isFinished'] is defined
-    - ansiblejob_info['resources'][0]['status']['isFinished']
+    - k8s_job['resources'][0] is not defined  # Job TTL expired
+    - ansiblejob_info['resources'][0]['status']['k8sJob']['created'] is defined
+    - ansiblejob_info['resources'][0]['status']['k8sJob']['created']
+    - launch_once
 
 - block:
     - name: Check number of attempts to execute the job have been made


### PR DESCRIPTION
Related to #166 

This is a small refgactoring of the "launch once" logic. Removing unnecessary `isFinished` flag from the status object, since the Ansible status already reports if the job is finished. In addition, I added a `launch_once` boolean in the CRD (defaults to true in order to keep the current logic), so that the user can influence how the reconcile loop works. If `launch_once` is explicitly set to false, the job template will be launched again after the job TTL expires.

This is particularly useful for self-healing infrastructure, where a reconciler is running an Ansible job that implements certain state, and the job is supposed to run again after TTL expired to enforce intended state

Example:

```yaml
---
apiVersion: tower.ansible.com/v1alpha1
kind: AnsibleJob
metadata:
  name: demo-launch-many
spec:
  connection_secret: awx-access
  job_template_name: Demo Job
  launch_once: false
```