### PR TITLE
Update kubernetes.core to 2.4.2 to fix k8s_cp module usage against OCP with virt

### DIFF
--- a/.github/workflows/kind-awx.yaml
+++ b/.github/workflows/kind-awx.yaml
@@ -29,7 +29,7 @@ jobs:
         run: podman save ${OPERATOR_IMAGE} > operator.tar
 
       - name: upload operator image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: operator.tar
           path: operator.tar
@@ -47,7 +47,7 @@ jobs:
         run: podman save ${RUNNER_IMAGE} > runner.tar
 
       - name: upload runner image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: runner.tar
           path: runner.tar
@@ -65,7 +65,7 @@ jobs:
         run: podman save ${TOKEN_IMAGE} > token.tar
 
       - name: upload token image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: token.tar
           path: token.tar
@@ -84,19 +84,19 @@ jobs:
           cpus: max
 
       - name: Pull the Container Image from Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: operator.tar
           path: /tmp
 
       - name: Pull the Container Image from Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: runner.tar
           path: /tmp
 
       - name: Pull the Container Image from Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: token.tar
           path: /tmp

--- a/molecule/requirements.yml
+++ b/molecule/requirements.yml
@@ -3,7 +3,7 @@ collections:
   - name: community.general
   - name: community.docker
   - name: kubernetes.core
-    version: "2.3.2"
+    version: "2.4.2"
   - name: operator_sdk.util
     version: "0.4.0"
   - name: awx.awx

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: kubernetes.core
-    version: "2.3.2"
+    version: "2.4.2"
   - name: operator_sdk.util
     version: "0.4.0"
   - name: awx.awx

--- a/test-e2e/token-container/requirements.yml
+++ b/test-e2e/token-container/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: kubernetes.core
-    version: "2.3.2"
+    version: "2.4.2"
   - name: operator_sdk.util
     version: "0.4.0"
   - name: awx.awx


### PR DESCRIPTION
Bumps kubernetes.core collection to match other operators we maintain.  Fixes k8s_cp bug on clusters with complex subresources like when Openshift Virtualization is installed.

Related k8s core issue:

>   - Resolve Collections util resource discovery fails when complex subresources
>     present (https://github.com/ansible-collections/kubernetes.core/pull/676).