### PR TITLE
Modify dev script to automatically create k8s connection secret from env vars

### DIFF
--- a/dev/create_oauth2_token.yml
+++ b/dev/create_oauth2_token.yml
@@ -1,0 +1,42 @@
+---
+- hosts: localhost
+  gather_facts: false
+  collections:
+    - awx.awx
+    - ansible.controller
+  tasks:
+    - name: Create OAuth2 token for admin user
+      block:
+        - name: Try with awx.awx.token
+          awx.awx.token:
+            description: "Auto-generated token by up.sh"
+            scope: "write"
+            state: present
+            controller_username: "{{ lookup('env', 'RESOURCE_SERVER_ADMIN_USER') }}"
+            controller_password: "{{ lookup('env', 'RESOURCE_SERVER_ADMIN_PASSWORD') }}"
+            controller_host: "{{ lookup('env', 'RESOURCE_SERVER_URL') }}"
+            validate_certs: false
+          register: token_result
+      rescue:
+        - name: Fallback to ansible.controller.token
+          ansible.controller.token:
+            description: "Auto-generated token by up.sh"
+            scope: "write"
+            state: present
+            controller_username: "{{ lookup('env', 'RESOURCE_SERVER_ADMIN_USER') }}"
+            controller_password: "{{ lookup('env', 'RESOURCE_SERVER_ADMIN_PASSWORD') }}"
+            controller_host: "{{ lookup('env', 'RESOURCE_SERVER_URL') }}"
+            validate_certs: false
+          register: token_result
+
+    - name: Set token as environment variable
+      set_fact:
+        oauth2_token: "{{ token_result.ansible_facts.tower_token.token }}"
+
+    - name: Display token information
+      debug:
+        msg: "Token created successfully: {{ oauth2_token }}"
+
+    - name: Export token to environment variable
+      shell: echo "export RESOURCE_SERVER_TOKEN={{ oauth2_token }}"
+      register: export_result

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,29 +14,44 @@ After cloning the repository and logging in to your OpenShift or Kubernetes clus
 export QUAY_USER=username
 export NAMESPACE=resource
 export TAG=test
-export RESOURCE_SERVER_URL="https://your-awx-instance.com"
-export RESOURCE_SERVER_TOKEN="your-awx-token"
 ./up.sh
 ```
-
-To make this persistent across sessions, consider adding these exports to your `.bashrc` or `.bash_profile`.
-
-> **Note**: The first run will attempt to push operator images to your Quay.io namespace. Ensure the resulting repositories are made **public** or configure a **global pull secret** in your OpenShift or Kubernetes cluster to avoid image pull issues.
 
 ---
 
 ## Connection Secret Configuration
 
-The operator requires a connection secret to communicate with your AWX instance. You can automatically create this secret during deployment by setting the following environment variables:
+The operator requires a connection secret to communicate with your AWX instance. There are two ways to configure this:
+
+### Option 1: Automatic OAuth2 Token Generation (Recommended)
+
+The operator can automatically generate an OAuth2 token using admin credentials. Simply set these environment variables:
+
+```bash
+export RESOURCE_SERVER_URL="https://your-awx-instance.com"
+export RESOURCE_SERVER_ADMIN_USER="admin"
+export RESOURCE_SERVER_ADMIN_PASSWORD="password"
+```
+
+When these variables are set, `up.sh` will:
+1. Automatically generate an OAuth2 token using the provided credentials
+2. Create a connection secret named `awxaccess` in your specified namespace
+3. Configure the operator to use this connection
+
+> **Note**: This method requires `ansible-playbook` to be installed on your system.
+
+### Option 2: Using an Existing OAuth2 Token
+
+If you prefer to use an existing token or cannot use automatic generation, set these environment variables:
 
 ```bash
 export RESOURCE_SERVER_URL="https://your-awx-instance.com"
 export RESOURCE_SERVER_TOKEN="your-awx-token"
 ```
 
-When these variables are set, `up.sh` will automatically create a connection secret named `awxaccess` in your specified namespace. If these variables are not set, the script will display a warning and skip secret creation.
+For information about manually creating tokens in AWX, see the [AWX documentation on token creation](https://docs.ansible.com/automation-controller/latest/html/userguide/applications_auth.html#add-tokens).
 
-To create an access token for AWX, see the [AWX documentation on token creation](https://docs.ansible.com/automation-controller/latest/html/userguide/applications_auth.html#add-tokens).
+If neither option's variables are set, the script will display a warning and skip secret creation.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,12 +14,29 @@ After cloning the repository and logging in to your OpenShift or Kubernetes clus
 export QUAY_USER=username
 export NAMESPACE=resource
 export TAG=test
+export RESOURCE_SERVER_URL="https://your-awx-instance.com"
+export RESOURCE_SERVER_TOKEN="your-awx-token"
 ./up.sh
 ```
 
 To make this persistent across sessions, consider adding these exports to your `.bashrc` or `.bash_profile`.
 
 > **Note**: The first run will attempt to push operator images to your Quay.io namespace. Ensure the resulting repositories are made **public** or configure a **global pull secret** in your OpenShift or Kubernetes cluster to avoid image pull issues.
+
+---
+
+## Connection Secret Configuration
+
+The operator requires a connection secret to communicate with your AWX instance. You can automatically create this secret during deployment by setting the following environment variables:
+
+```bash
+export RESOURCE_SERVER_URL="https://your-awx-instance.com"
+export RESOURCE_SERVER_TOKEN="your-awx-token"
+```
+
+When these variables are set, `up.sh` will automatically create a connection secret named `awxaccess` in your specified namespace. If these variables are not set, the script will display a warning and skip secret creation.
+
+To create an access token for AWX, see the [AWX documentation on token creation](https://docs.ansible.com/automation-controller/latest/html/userguide/applications_auth.html#add-tokens).
 
 ---
 

--- a/up.sh
+++ b/up.sh
@@ -3,7 +3,7 @@
 # -- Usage Notes
 #
 # If you are testing changes to the runner image and need to build it,
-# you must specify the runner image in manager.yml to use it, or on the 
+# you must specify the runner image in manager.yml to use it, or on the
 # job CR as runner_image and runner_version. The default value is quay.io/$QUAY_USER/awx-resource-runner:dev
 
 # -- Prepare
@@ -35,6 +35,16 @@ done
 
 # -- Usage
 #   NAMESPACE=resource TAG=dev QUAY_USER=developer ./up.sh
+#
+# -- Environment Variables for AWX/Controller Connection
+#   RESOURCE_SERVER_URL - URL of the AWX/Controller server
+#   RESOURCE_SERVER_TOKEN - OAuth2 token for authentication
+#
+# -- Automatic OAuth2 Token Generation
+#   If RESOURCE_SERVER_TOKEN is not set but the following variables are set,
+#   the script will attempt to automatically create an OAuth2 token:
+#   RESOURCE_SERVER_ADMIN_USER - Admin username
+#   RESOURCE_SERVER_ADMIN_PASSWORD - Admin password
 
 # -- User Variables
 NAMESPACE=${NAMESPACE:-resource}
@@ -145,6 +155,34 @@ make deploy IMG=$IMG:$TAG NAMESPACE=$NAMESPACE
 # Deploy Operator
 NAMESPACE=$NAMESPACE IMG=quay.io/chadams/awx-resource-operator:$TAG make deploy # RUNNER_IMG=quay.io/chadams/awx-resource-runner:dev
 
+# -- Check for admin credentials and create OAuth2 token if available
+if [ -n "$RESOURCE_SERVER_ADMIN_USER" ] && [ -n "$RESOURCE_SERVER_ADMIN_PASSWORD" ] && [ -n "$RESOURCE_SERVER_URL" ] && [ -z "$RESOURCE_SERVER_TOKEN" ]; then
+    echo "Admin credentials found. Attempting to create OAuth2 token..."
+
+    # Check if ansible-playbook is available
+    if command -v ansible-playbook &> /dev/null; then
+        # Run the playbook to create the token
+        ANSIBLE_STDOUT_CALLBACK=json ansible-playbook dev/create_oauth2_token.yml > token_output.json
+
+        # Extract the token from the playbook output
+        if [ -f token_output.json ]; then
+            RESOURCE_SERVER_TOKEN=$(grep -o '"oauth2_token": "[^"]*"' token_output.json | cut -d'"' -f4)
+            if [ -n "$RESOURCE_SERVER_TOKEN" ]; then
+                echo "OAuth2 token created successfully."
+                # Clean up temporary files
+                rm -f token_output.json
+            else
+                echo "Failed to extract OAuth2 token from playbook output."
+            fi
+        else
+            echo "Playbook execution failed or output file not created."
+        fi
+    else
+        echo "ansible-playbook command not found. Cannot create OAuth2 token automatically."
+        echo "Please install ansible or set RESOURCE_SERVER_TOKEN manually."
+    fi
+fi
+
 # -- Create connection secret using environment variables
 if [ -z "$RESOURCE_SERVER_URL" ] || [ -z "$RESOURCE_SERVER_TOKEN" ]; then
     echo "Warning: RESOURCE_SERVER_URL and/or RESOURCE_SERVER_TOKEN not set. Skipping connection secret creation."
@@ -165,5 +203,5 @@ fi
 
 
 # Create custom resources
-#oc create -f awxaccess-secret.yml 
+#oc create -f awxaccess-secret.yml
 #oc create -f launch_jt_cr.yml

--- a/up.sh
+++ b/up.sh
@@ -145,8 +145,23 @@ make deploy IMG=$IMG:$TAG NAMESPACE=$NAMESPACE
 # Deploy Operator
 NAMESPACE=$NAMESPACE IMG=quay.io/chadams/awx-resource-operator:$TAG make deploy # RUNNER_IMG=quay.io/chadams/awx-resource-runner:dev
 
-# Prepare files
-oc create -f hacking/awxaccess-secret.yml 
+# -- Create connection secret using environment variables
+if [ -z "$RESOURCE_SERVER_URL" ] || [ -z "$RESOURCE_SERVER_TOKEN" ]; then
+    echo "Warning: RESOURCE_SERVER_URL and/or RESOURCE_SERVER_TOKEN not set. Skipping connection secret creation."
+else
+    cat <<EOF | kubectl apply -n $NAMESPACE -f -
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: awxaccess
+stringData:
+  host: "${RESOURCE_SERVER_URL}"
+  token: "${RESOURCE_SERVER_TOKEN}"
+type: Opaque
+EOF
+    echo "Created connection secret 'awxaccess' in namespace $NAMESPACE"
+fi
 
 
 # Create custom resources


### PR DESCRIPTION
# Improve OAuth2 Token Generation

This allows you to create the connection secret on the fly.


## Changes
- Add automatic fallback to `ansible.controller.token` if `awx.awx.token` fails
- Update documentation to recommend automatic token generation as the primary method
- Clarify the token generation process in development guide
- Alternatively, if token env var and url are set as environment variables, a k8s secret will be created accordingly.

## Why
Currently, if the `awx.awx.token` module fails, the token generation process fails completely. This change provides more robust token generation by falling back to the `ansible.controller.token` module, improving reliability across different AWX/Controller versions.

## Testing
1. Test with AWX url, username and password provided:
```bash
export RESOURCE_SERVER_URL="https://your-awx-instance.com"
export RESOURCE_SERVER_ADMIN_USER="admin"
export RESOURCE_SERVER_ADMIN_PASSWORD="password"
./up.sh
```

2. Test with url and token provided

```bash
export QUAY_USER=username
export NAMESPACE=resource
export TAG=test
export RESOURCE_SERVER_URL="https://your-awx-instance.com"
export RESOURCE_SERVER_TOKEN="your-awx-token"
./up.sh
```

If not passed, it just skips.