### PR TITLE
Update collections to match other operators and use kubernetes.core 3.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.22.2
+FROM quay.io/operator-framework/ansible-operator:v1.36.1
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ ifeq (,$(shell which ansible-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(ANSIBLE_OPERATOR)) ;\
-	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.22.2/ansible-operator_$(OS)_$(ARCH) ;\
+	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.36.1/ansible-operator_$(OS)_$(ARCH) ;\
 	chmod +x $(ANSIBLE_OPERATOR) ;\
 	}
 else

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: kubernetes.core
-    version: "2.4.2"
+    version: "3.2.0"
   - name: operator_sdk.util
-    version: "0.4.0"
+    version: "0.5.0"
   - name: awx.awx
     version: ">=22.7.0"


### PR DESCRIPTION
SUMMARY
We are now able to update to kubernetes.core 3.2.0.

ADDITIONAL INFORMATION
We will now have the same collection versions across the board.