### PR TITLE
fix: pin kubernetes>=36.0.2 to fix in-cluster auth regression

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -6,7 +6,7 @@ COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml --force \
  && chmod -R ug+rwx ${HOME}/.ansible && mkdir -p ${HOME}/roles
 
-RUN pip3 install awxkit kubernetes openshift
+RUN pip3 install awxkit 'kubernetes>=36.0.1' openshift
 
 COPY roles/job_runner ${HOME}/roles/job_runner
 CMD ["ansible-runner", "run", "/runner", "--hosts", "localhost", "--role", "job_runner", "--role-skip-facts"]


### PR DESCRIPTION
## Summary
- Pin `kubernetes>=36.0.2` in `Dockerfile.runner` to fix in-cluster auth regression

## Root Cause
Python `kubernetes` client v36.0.0 has a regression where `config.load_incluster_config()` loads the SA token into the Configuration object but `ApiClient` does not include the `Authorization` header in HTTP requests.

This causes the runner pod to authenticate as `system:anonymous` to the K8s API. The "Read AnsibleJob Specs" task fails with `403 Forbidden` before the job launch ever happens.

**Evidence from debug pod using the runner image:**
- `config.load_incluster_config()` succeeds, token loaded (1633 chars, valid JWT)
- `ApiClient` sends requests with headers: `Accept`, `User-Agent`, `Content-Type` — **no Authorization header**
- Same SA token via `curl` from the same pod → HTTP 200
- Same SA token via `urllib3` direct call → HTTP 200
- Python `kubernetes.client.CoreV1Api` → 403 Forbidden, `system:anonymous`

Fixed in `kubernetes>=36.0.2`.

## Test plan
- [ ] Build runner image and verify AnsibleJob "Read AnsibleJob Specs" task passes
- [ ] Verify runner pod authenticates to K8s API as the service account, not `system:anonymous`

Ref: AAP-78115